### PR TITLE
Typo in MirvCommands.cpp

### DIFF
--- a/AfxHookSource/MirvCommands.cpp
+++ b/AfxHookSource/MirvCommands.cpp
@@ -2629,7 +2629,7 @@ CON_COMMAND(mirv_listentities, "Print info about currently active entites. (CS:G
 	Tier0_Msg(
 		"\n"
 		"Usage:\n"
-		"mirv_listentites [isPlayer=1] [sort=distance] [class=<wildCardString(\\* = wildcard, \\\\ = \\)>]\n"
+		"mirv_listentities [isPlayer=1] [sort=distance] [class=<wildCardString(\\* = wildcard, \\\\ = \\)>]\n"
 	);
 
 


### PR DESCRIPTION
mirv_listentites -> mirv_listentities (https://github.com/advancedfx/advancedfx/issues/680 1.)