### PR TITLE
Allow camera roll modification

### DIFF
--- a/AfxHookGoldSrc/filming.cpp
+++ b/AfxHookGoldSrc/filming.cpp
@@ -276,6 +276,7 @@ void do_camera_test(float vieworg[3], float viewangles[3]) {
 		pEngfuncs->pfnCenterPrint("zZz");
 }
 
+
 void Filming::FovOverride(double value)
 {
 	m_FovValue = value;
@@ -285,6 +286,17 @@ void Filming::FovOverride(double value)
 void Filming::FovDefault()
 {
 	m_FovOverride = false;
+}
+
+void Filming::RollOverride(double value)
+{
+	m_RollValue = value;
+	m_RollOverride = true;
+}
+
+void Filming::RollDefault()
+{
+	m_RollOverride = false;
 }
 
 void Filming::OnR_RenderView(float vieworg[3], float viewangles[3], float & fov)
@@ -305,9 +317,10 @@ void Filming::OnR_RenderView(float vieworg[3], float viewangles[3], float & fov)
 	}
 
 	if(m_FovOverride)
-	{
 		fov = (float)m_FovValue;
-	}
+
+	if(m_RollOverride)
+		viewangles[ROLL] = (float)m_RollValue;
 
 	//
 	// Camera spline interaction:
@@ -2441,6 +2454,33 @@ REGISTER_CMD_FUNC(fov)
 		"Usage:\n"
 		PREFIX "fov f - Override fov with given floating point value (f).\n"
 		PREFIX "fov default - Revert to the game's default behaviour.\n"
+	);
+}
+
+REGISTER_CMD_FUNC(roll)
+{
+	int argc = pEngfuncs->Cmd_Argc();;
+
+	if(2 <= argc)
+	{
+		char const * arg1 = pEngfuncs->Cmd_Argv(1);
+
+		if(0 == _stricmp("default", arg1))
+		{
+			g_Filming.RollDefault();
+			return;
+		}
+		else
+		{
+			g_Filming.RollOverride(atof(arg1));
+			return;
+		}
+	}
+
+	pEngfuncs->Con_Printf(
+		"Usage:\n"
+		PREFIX "roll f - Override camera roll with given floating point value (f).\n"
+		PREFIX "v default - Revert to the game's default behaviour.\n"
 	);
 }
 

--- a/AfxHookGoldSrc/filming.h
+++ b/AfxHookGoldSrc/filming.h
@@ -106,6 +106,9 @@ public:
 
 	void FovOverride(double value);
 	void FovDefault();
+	
+	void RollOverride(double value);
+	void RollDefault();
 
 	// used in OpenGl32Hooks.cpp
 	void FullClear();
@@ -217,7 +220,9 @@ private:
 	bool m_DebugCapture;
 	bool m_EnableStereoMode;
 	bool m_FovOverride;
+	bool m_RollOverride;
 	double m_FovValue;
+	double m_RollValue;
 	int m_Height;
 	unsigned int m_HostFrameCount;
 	bool m_HudDrawnInFrame;


### PR DESCRIPTION
Currently in GoldSrc its only possible to modify the camera roll by exporting the campath, modifying it in a text editor, then reimporting it. The workflow is pretty cumbersome. This should allow for a better experience when creating specific camera angles without having to go back and forth between programs to do changes.