### PR TITLE
Stop mirv_fov from overriding the fov when the player is zoomed-in.

### DIFF
--- a/AfxHookGoldSrc/filming.cpp
+++ b/AfxHookGoldSrc/filming.cpp
@@ -288,6 +288,11 @@ void Filming::FovDefault()
 	m_FovOverride = false;
 }
 
+void Filming::FovZoomFix(bool value)
+{
+	m_FovZoomFix = value;
+}
+
 void Filming::RollOverride(double value)
 {
 	m_RollValue = value;
@@ -316,7 +321,12 @@ void Filming::OnR_RenderView(float vieworg[3], float viewangles[3], float & fov)
 		viewangles[ROLL] = (float)A.Roll;
 	}
 
-	if(m_FovOverride)
+	if (m_FovZoomFix && m_FovOverride) 
+	{
+		if(fov == 90.0f)
+			fov = (float)m_FovValue;
+	}
+	else if(m_FovOverride) 
 		fov = (float)m_FovValue;
 
 	if(m_RollOverride)
@@ -2454,6 +2464,32 @@ REGISTER_CMD_FUNC(fov)
 		"Usage:\n"
 		PREFIX "fov f - Override fov with given floating point value (f).\n"
 		PREFIX "fov default - Revert to the game's default behaviour.\n"
+	);
+}
+
+REGISTER_CMD_FUNC(fov_zoom_fix)
+{
+	int argc = pEngfuncs->Cmd_Argc();;
+
+	if (2 <= argc)
+	{
+		char const* arg1 = pEngfuncs->Cmd_Argv(1);
+
+		if (0 == _stricmp("1", arg1))
+		{
+			g_Filming.FovZoomFix(true);
+			return;
+		}
+		else
+		{
+			g_Filming.FovZoomFix(false);
+			return;
+		}
+	}
+
+	pEngfuncs->Con_Printf(
+		"Usage:\n"
+		PREFIX "fov_zoom_fix 0 | 1 - Stops mirv_fov from overriding the default fov when the player is zooming in.\n"
 	);
 }
 

--- a/AfxHookGoldSrc/filming.cpp
+++ b/AfxHookGoldSrc/filming.cpp
@@ -288,11 +288,6 @@ void Filming::FovDefault()
 	m_FovOverride = false;
 }
 
-void Filming::FovZoomFix(bool value)
-{
-	m_FovZoomFix = value;
-}
-
 void Filming::RollOverride(double value)
 {
 	m_RollValue = value;
@@ -321,12 +316,7 @@ void Filming::OnR_RenderView(float vieworg[3], float viewangles[3], float & fov)
 		viewangles[ROLL] = (float)A.Roll;
 	}
 
-	if (m_FovZoomFix && m_FovOverride) 
-	{
-		if(fov == 90.0f)
-			fov = (float)m_FovValue;
-	}
-	else if(m_FovOverride) 
+	if (m_FovOverride && (!m_HandleZoomEnabled || m_HandleZoomMinUnzoomedFov <= fov))
 		fov = (float)m_FovValue;
 
 	if(m_RollOverride)
@@ -588,9 +578,11 @@ Filming::Filming()
 	_fx_whRGBf[1]=0.5f;	
 	_fx_whRGBf[2]=1.0f;
 
-	 bRequestingMatteTextUpdate=false;
+	m_HandleZoomEnabled = false;
+	m_HandleZoomMinUnzoomedFov = 90.0f;
 
-	 matte_entities_r.bNotEmpty=false; // by default empty
+	bRequestingMatteTextUpdate=false;
+	matte_entities_r.bNotEmpty=false; // by default empty
 }
 
 Filming::~Filming()
@@ -2453,10 +2445,54 @@ REGISTER_CMD_FUNC(fov)
 			g_Filming.FovDefault();
 			return;
 		}
-		else
+
+		if(atof(arg1) != 0.0f)
 		{
 			g_Filming.FovOverride(atof(arg1));
 			return;
+		}
+		
+		if (0 == _stricmp("handleZoom", arg1))
+		{
+			if (3 <= argc)
+			{
+				const char* arg2 = pEngfuncs->Cmd_Argv(2);
+
+				if (!_stricmp(arg2, "enabled"))
+				{
+					if (4 <= argc)
+					{
+						const char* arg3 = pEngfuncs->Cmd_Argv(3);
+						g_Filming.m_HandleZoomEnabled = atoi(arg3);
+
+						return;
+					}
+
+					pEngfuncs->Con_Printf(
+						"Usage:\n"
+						PREFIX "mirv_fov handleZoom enabled 0|1 - Enable (1), disable (0).\n"
+						PREFIX "Current value: %s\n", g_Filming.m_HandleZoomEnabled ? "1" : "0"
+					);
+					return;
+				}
+				else if (!_stricmp(arg2, "minUnzoomedFov"))
+				{
+					const char* arg3 = pEngfuncs->Cmd_Argv(3);
+
+					if (atof(arg3) != 0.0f) 
+					{
+						g_Filming.m_HandleZoomMinUnzoomedFov = atof(arg3);
+						return;
+					}
+
+					pEngfuncs->Con_Printf(
+						"Usage:\n"
+						PREFIX "mirv_fov handleZoom minUnzoomedFov f - Set minimum fov as threshold.\n"
+						PREFIX "Current value: %f\n", g_Filming.m_HandleZoomMinUnzoomedFov
+					);
+					return;
+				}
+			}
 		}
 	}
 
@@ -2464,32 +2500,8 @@ REGISTER_CMD_FUNC(fov)
 		"Usage:\n"
 		PREFIX "fov f - Override fov with given floating point value (f).\n"
 		PREFIX "fov default - Revert to the game's default behaviour.\n"
-	);
-}
-
-REGISTER_CMD_FUNC(fov_zoom_fix)
-{
-	int argc = pEngfuncs->Cmd_Argc();;
-
-	if (2 <= argc)
-	{
-		char const* arg1 = pEngfuncs->Cmd_Argv(1);
-
-		if (0 == _stricmp("1", arg1))
-		{
-			g_Filming.FovZoomFix(true);
-			return;
-		}
-		else
-		{
-			g_Filming.FovZoomFix(false);
-			return;
-		}
-	}
-
-	pEngfuncs->Con_Printf(
-		"Usage:\n"
-		PREFIX "fov_zoom_fix 0 | 1 - Stops mirv_fov from overriding the default fov when the player is zooming in.\n"
+		PREFIX "fov handleZoom enabled [...] - Whether to enable zoom handling (if enabled mirv_fov is only active if it's not below minUnzoomedFov (not zoomed)).\n"
+		PREFIX "fov handleZoom minUnzoomedFov [...] - Zoom detection threshold.\n"
 	);
 }
 

--- a/AfxHookGoldSrc/filming.h
+++ b/AfxHookGoldSrc/filming.h
@@ -105,7 +105,6 @@ public:
 	~Filming();
 
 	void FovOverride(double value);
-	void FovZoomFix(bool bEnable);
 	void FovDefault();
 	
 	void RollOverride(double value);
@@ -183,6 +182,8 @@ public:
 	double LastCameraAngles[3];
 	double LastCameraFov;
 
+	bool m_HandleZoomEnabled;
+	float m_HandleZoomMinUnzoomedFov;
 
 	void GetCameraOfs(float &right, float &up, float &forward); // will copy the current camera ofs to the supplied addresses
 	void GetCameraAngs(float& pitch, float& yaw, float& roll);
@@ -221,7 +222,6 @@ private:
 	bool m_DebugCapture;
 	bool m_EnableStereoMode;
 	bool m_FovOverride;
-	bool m_FovZoomFix;
 	bool m_RollOverride;
 	double m_FovValue;
 	double m_RollValue;

--- a/AfxHookGoldSrc/filming.h
+++ b/AfxHookGoldSrc/filming.h
@@ -105,6 +105,7 @@ public:
 	~Filming();
 
 	void FovOverride(double value);
+	void FovZoomFix(bool bEnable);
 	void FovDefault();
 	
 	void RollOverride(double value);
@@ -220,6 +221,7 @@ private:
 	bool m_DebugCapture;
 	bool m_EnableStereoMode;
 	bool m_FovOverride;
+	bool m_FovZoomFix;
 	bool m_RollOverride;
 	double m_FovValue;
 	double m_RollValue;


### PR DESCRIPTION
When mirv_fov is set to a value other than "default", weapons which you can zoom in with are not overriding the fov. The problem with the way it currently works is that recording footage at a aspect ratio different from 4:3 requires the fov to be altered, else the footage will look too narrow. More information about the aspect ratio fov issue can be found here https://github.com/ValveSoftware/halflife/issues/1978 and https://github.com/ValveSoftware/halflife/issues/748.

A cvar is added to disallow mirv_fov to override the fov if the default fov got altered.