### PR TITLE
Missing return;

### DIFF
--- a/AfxHookSource/AfxStreams.cpp
+++ b/AfxHookSource/AfxStreams.cpp
@@ -11384,6 +11384,7 @@ void CAfxSamplingRecordingSettings::Console_Edit(IWrpCommandArgs * args)
 				}
 
 				m_OutFps = (float)atof(args->ArgV(2));
+				return;
 			}
 
 			Tier0_Msg(


### PR DESCRIPTION
Otherwise the console outputs the help message when you have entered a value/number.