### PR TITLE
Removed commas from mirv_campath print output

### DIFF
--- a/shared/MirvCampath.cpp
+++ b/shared/MirvCampath.cpp
@@ -165,7 +165,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 		}
 		else if (!_stricmp("print", subcmd) && 2 == argc)
 		{
-			conMessage("passed? selected? id : tick[offset](approximate!) , demoTime[offset](approximate!) , gameTime[offset] -> ( x , y , z ) fov ( pitch , yaw , roll )\n");
+			conMessage("passed? selected? id : tick[offset](approximate!) , demoTime[offset](approximate!) , gameTime[offset] -> ( x y z ) fov ( pitch yaw roll )\n");
 
 			double curtime = mirvTime->GetTime();
 
@@ -239,7 +239,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 
 				if (offset > 0)
 				{
-					conMessage(" , %f+%f -> ( %f , %f , %f ) %f ( %f , %f , %f )\n",
+					conMessage(" , %f+%f -> ( %f %f %f ) %f ( %f %f %f )\n",
 						time, offset,
 						vieworigin[0], vieworigin[1], vieworigin[2],
 						fov,
@@ -248,7 +248,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 				}
 				else if (offset < 0)
 				{
-					conMessage(" , %f%f -> ( %f , %f , %f ) %f ( %f , %f , %f )\n",
+					conMessage(" , %f%f -> ( %f %f %f ) %f ( %f %f %f )\n",
 						time, offset,
 						vieworigin[0], vieworigin[1], vieworigin[2],
 						fov,
@@ -257,7 +257,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 				}
 				else
 				{
-					conMessage(" , %f -> ( %f , %f , %f ) %f ( %f , %f , %f )\n",
+					conMessage(" , %f -> ( %f %f %f ) %f ( %f %f %f )\n",
 						time,
 						vieworigin[0], vieworigin[1], vieworigin[2],
 						fov,
@@ -292,7 +292,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 
 			SMirvCameraValue camera = mirvCamera->GetCamera();
 
-			conMessage("Current ( x , y , z ) fov ( pitch , yaw , roll ): ( %f , %f , %f ) %f ( %f , %f , %f )\n",
+			conMessage("Current ( x y z ) fov ( pitch yaw roll ): ( %f %f %f ) %f ( %f %f %f )\n",
 				camera.X,
 				camera.Y,
 				camera.Z,

--- a/shared/MirvCampath.cpp
+++ b/shared/MirvCampath.cpp
@@ -239,7 +239,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 
 				if (offset > 0)
 				{
-					conMessage(" , %f+%f -> ( %f %f %f ) %f ( %f %f %f )\n",
+					conMessage(" , %f+%f -> ( %f  %f  %f ) %f ( %f  %f  %f )\n",
 						time, offset,
 						vieworigin[0], vieworigin[1], vieworigin[2],
 						fov,
@@ -248,7 +248,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 				}
 				else if (offset < 0)
 				{
-					conMessage(" , %f%f -> ( %f %f %f ) %f ( %f %f %f )\n",
+					conMessage(" , %f%f -> ( %f  %f  %f ) %f ( %f  %f  %f )\n",
 						time, offset,
 						vieworigin[0], vieworigin[1], vieworigin[2],
 						fov,
@@ -257,7 +257,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 				}
 				else
 				{
-					conMessage(" , %f -> ( %f %f %f ) %f ( %f %f %f )\n",
+					conMessage(" , %f -> ( %f  %f  %f ) %f ( %f  %f  %f )\n",
 						time,
 						vieworigin[0], vieworigin[1], vieworigin[2],
 						fov,
@@ -292,7 +292,7 @@ void MirvCampath_ConCommand(advancedfx::ICommandArgs* args, advancedfx::Con_Prin
 
 			SMirvCameraValue camera = mirvCamera->GetCamera();
 
-			conMessage("Current ( x y z ) fov ( pitch yaw roll ): ( %f %f %f ) %f ( %f %f %f )\n",
+			conMessage("Current ( x y z ) fov ( pitch yaw roll ): ( %f  %f  %f ) %f ( %f  %f  %f )\n",
 				camera.X,
 				camera.Y,
 				camera.Z,


### PR DESCRIPTION
Full changelog:

_Removed commas from `mirv_campath print` output for X Y Z and pitch yaw roll to be more convenient when copy/pasting into `mirv_input position/angles`, and added more space in between those values for easier readability. Those extra spaces can still be pasted into `mirv_input position/angles`._

Related suggestion: https://github.com/advancedfx/advancedfx/issues/827