### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3.6.0
-    - uses: MinoruSekine/setup-scoop@main
+    - uses: MinoruSekine/setup-scoop@v4
 
     - name: Update submodules
       run: git submodule update --init --recursive


### PR DESCRIPTION
Fixes CI that stopped working two commits ago by making the `setup-scoop` GitHub action use `v4` version instead of `main` one