### PR TITLE
Improved parameters in HLAE interfaces

### DIFF
--- a/hlae/Globals.cs
+++ b/hlae/Globals.cs
@@ -6,11 +6,13 @@ class Globals
     internal static bool AutoStartCsgo { get { return m_AutoStartCsgo; } set { m_AutoStartCsgo = value; } }
     internal static bool AutoStartCustomLoader { get { return m_AutoStartCustomLoader; } set { m_AutoStartCustomLoader = value; } }
     internal static bool NoGui { get { return m_NoGui; } set { m_NoGui = value; } }
+    internal static bool NoConfig { get { return m_NoConfig; } set { m_NoConfig = value; } }
 
     static bool m_AutoStartAfxHookGoldSrc;
     static bool m_AutoStartCsgo;
     static bool m_AutoStartCustomLoader;
     static bool m_NoGui;
+    static bool m_NoConfig;
 }
 
 class GlobalConfig

--- a/hlae/Program.cs
+++ b/hlae/Program.cs
@@ -336,6 +336,10 @@ namespace AfxGui
             {
                 ProcessArgsCsgoLauncher(argv);
             }
+			else if (Array.Exists<string>(argv, p => p == "-afxHookGoldSrc"))
+			{
+				ProcessArgsAfxHookGoldSrc(argv);
+			}
         }
 
         /// <summary>

--- a/hlae/Program.cs
+++ b/hlae/Program.cs
@@ -322,6 +322,12 @@ namespace AfxGui
                 argv = tmp;
             }
 
+            if (Array.Exists<string>(argv, p => p == "-noConfig"))
+            {
+				GlobalConfig.Instance = new Config();
+				Globals.NoConfig = true;
+            }
+
             if (Array.Exists<string>(argv, p => p == "-customLoader"))
             {
                 ProcessArgsCustomLoader(argv);
@@ -424,8 +430,11 @@ namespace AfxGui
             {
                 Application.Run(new MainForm());
             }
-
-            GlobalConfig.Instance.BackUp();
+			
+			if(!Globals.NoConfig)
+			{
+				GlobalConfig.Instance.BackUp();
+			}
 
             GlobalUpdateCheck.Instance.Dispose();
 


### PR DESCRIPTION
- Added `-noConfig` parameter. If passed, then config will be set to default (empty) and won't be saved. Useful, when running HLAE from CLI or programmatically and don't want to override user's settings. 
- Fixed bug, where `-afxHookGoldSrc` parameter wasn't handled.

If you merge PR, then add following to [wiki page.](https://github.com/advancedfx/advancedfx/wiki/HLAE-Interfaces) Maybe put it right after examples or at the very end?

 `-noConfig` 
If passed, then config file is not used and settings won't be saved. This parameter can be used with any launch option. 

