### PR TITLE
mirv-script cvars feature

### DIFF
--- a/AfxHookSource2/CMakeLists.txt
+++ b/AfxHookSource2/CMakeLists.txt
@@ -133,13 +133,14 @@ target_sources(${PROJECT_NAME} PRIVATE
     ../deps/release/prop/cs2/sdk_src/public/tier1/bufferstring.cpp
     ../deps/release/prop/cs2/sdk_src/public/tier1/bufferstring.h
     ../deps/release/prop/cs2/sdk_src/public/vstdlib/IKeyValuesSystem.h
-    ../deps/release/prop/cs2/sdk_src/public/cdll_int.h    
-    ../deps/release/prop/cs2/sdk_src/public/filesystem.h    
-    ../deps/release/prop/cs2/sdk_src/public/const.h    
-    ../deps/release/prop/cs2/sdk_src/public/entityhandle.h    
-    ../deps/release/prop/cs2/sdk_src/public/icvar.h    
-    ../deps/release/prop/cs2/sdk_src/public/igameevents.h    
-    ../deps/release/prop/cs2/sdk_src/public/igameuiservice.h    
+    ../deps/release/prop/cs2/sdk_src/public/Color.h
+    ../deps/release/prop/cs2/sdk_src/public/cdll_int.h
+    ../deps/release/prop/cs2/sdk_src/public/filesystem.h
+    ../deps/release/prop/cs2/sdk_src/public/const.h
+    ../deps/release/prop/cs2/sdk_src/public/entityhandle.h
+    ../deps/release/prop/cs2/sdk_src/public/icvar.h
+    ../deps/release/prop/cs2/sdk_src/public/igameevents.h
+    ../deps/release/prop/cs2/sdk_src/public/igameuiservice.h
     ../deps/release/prop/cs2/sdk_src/tier1/KeyValues.cpp
     ../deps/release/prop/AfxHookSource/SourceSdkShared.cpp
     ../deps/release/prop/AfxHookSource/SourceSdkShared.h
@@ -214,6 +215,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ClientEntitySystem.h
 
     ConsoleRs.cpp
+    CVarRs.cpp
 
 	DeathMsg.cpp
 	DeathMsg.h

--- a/AfxHookSource2/CVarRs.cpp
+++ b/AfxHookSource2/CVarRs.cpp
@@ -85,6 +85,22 @@ extern "C" int16_t afx_hook_source2_get_convar_type(CVarRs_t * p_cvar) {
     return static_cast<int16_t>(CVarTypeRs_e::Invalid);
 }
 
+extern "C" FFIBool afx_hook_source2_get_convar_name(CVarRs_t * p_cvar, const char * &outValue) {
+    if(p_cvar) {
+        outValue = p_cvar->m_pszName;
+        return FFIBOOL_TRUE;
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_get_convar_help_string(CVarRs_t * p_cvar, const char * &outValue) {
+    if(p_cvar) {
+        outValue = p_cvar->m_pszHelpString;
+        return FFIBOOL_TRUE;
+    }
+    return FFIBOOL_FALSE;
+}
+
 enum class CVarGetMode_e : int8_t {
     Value = 0,
     DefaultValue = 1,

--- a/AfxHookSource2/CVarRs.cpp
+++ b/AfxHookSource2/CVarRs.cpp
@@ -56,7 +56,7 @@ extern "C" int16_t afx_hook_source2_get_convar_type(CVarRs_t * p_cvar) {
         case SOURCESDK::CS2::EConVarType_UInt16:
             return static_cast<int16_t>(CVarTypeRs_e::UInt16);
         case SOURCESDK::CS2::EConVarType_Int32:
-            return static_cast<int16_t>(CVarTypeRs_e::UInt32);
+            return static_cast<int16_t>(CVarTypeRs_e::Int32);
         case SOURCESDK::CS2::EConVarType_UInt32:
             return static_cast<int16_t>(CVarTypeRs_e::UInt32);
         case SOURCESDK::CS2::EConVarType_Int64:

--- a/AfxHookSource2/CVarRs.cpp
+++ b/AfxHookSource2/CVarRs.cpp
@@ -11,17 +11,16 @@ typedef SOURCESDK::CS2::Cvar_s CVarRs_t;
 
 extern "C" size_t afx_hook_source2_find_convar_index(const char * psz_name) {
     if(SOURCESDK::CS2::g_pCVar) {
-        return SOURCESDK::CS2::g_pCVar->FindConVar(psz_name, false).Get();
+        SOURCESDK::CS2::ConVarHandle handle = SOURCESDK::CS2::g_pCVar->FindConVar(psz_name, false);
+        return handle.IsValid() ? handle.Get() : -1;
     }
     return -1;
 }
 
-extern "C" FFIBool afx_hook_source2_is_convar_index_valid(size_t index) {
-    return BOOL_TO_FFIBOOL(-1 != index);
-}
-
 extern "C" CVarRs_t * afx_hook_source2_get_convar(size_t index) {
-    if(SOURCESDK::CS2::g_pCVar) {
+    if(SOURCESDK::CS2::g_pCVar
+        && index < SOURCESDK_CS2_MAX_VALID_CVARS // otherwise crash / invalid pointer ... :)
+    ) {
         return SOURCESDK::CS2::g_pCVar->GetCvar(index);
     }
 

--- a/AfxHookSource2/CVarRs.cpp
+++ b/AfxHookSource2/CVarRs.cpp
@@ -1,0 +1,1192 @@
+#include "stdafx.h"
+
+#include "../shared/FFITools.h"
+
+#include "../shared/AfxConsole.h"
+
+#include "../deps/release/prop/cs2/sdk_src/public/tier1/convar.h"
+#include "../deps/release/prop/cs2/sdk_src/public/icvar.h"
+
+typedef SOURCESDK::CS2::Cvar_s CVarRs_t;
+
+extern "C" size_t afx_hook_source2_find_convar_index(const char * psz_name) {
+    if(SOURCESDK::CS2::g_pCVar) {
+        return SOURCESDK::CS2::g_pCVar->FindConVar(psz_name, false).Get();
+    }
+    return -1;
+}
+
+extern "C" FFIBool afx_hook_source2_is_convar_index_valid(size_t index) {
+    return BOOL_TO_FFIBOOL(-1 != index);
+}
+
+extern "C" CVarRs_t * afx_hook_source2_get_convar(size_t index) {
+    if(SOURCESDK::CS2::g_pCVar) {
+        return SOURCESDK::CS2::g_pCVar->GetCvar(index);
+    }
+
+    return nullptr;
+}
+
+enum class CVarTypeRs_e : int16_t {
+	Invalid = -1,
+	Bool = 0,
+	Int16 = 1,
+	UInt16 = 2,
+	Int32 = 3,
+	UInt32 = 4,
+	Int64 = 5,
+	UInt64 = 6,
+	Float32 = 7,
+	Float64 = 8,
+	String = 9,
+	Color = 10,
+	Vector2 = 11,
+	Vector3 = 12,
+	Vector4 = 13,
+	Qangle = 14
+};
+
+extern "C" int16_t afx_hook_source2_get_convar_type(CVarRs_t * p_cvar) {
+    if(p_cvar) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            return static_cast<int16_t>(CVarTypeRs_e::Bool);
+        case SOURCESDK::CS2::EConVarType_Int16:
+            return static_cast<int16_t>(CVarTypeRs_e::Int16);
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            return static_cast<int16_t>(CVarTypeRs_e::UInt16);
+        case SOURCESDK::CS2::EConVarType_Int32:
+            return static_cast<int16_t>(CVarTypeRs_e::UInt32);
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            return static_cast<int16_t>(CVarTypeRs_e::UInt32);
+        case SOURCESDK::CS2::EConVarType_Int64:
+            return static_cast<int16_t>(CVarTypeRs_e::Int64);
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            return static_cast<int16_t>(CVarTypeRs_e::UInt64);
+        case SOURCESDK::CS2::EConVarType_Float32:
+            return static_cast<int16_t>(CVarTypeRs_e::Float32);
+        case SOURCESDK::CS2::EConVarType_Float64:
+            return static_cast<int16_t>(CVarTypeRs_e::Float64);
+        case SOURCESDK::CS2::EConVarType_String:
+            return static_cast<int16_t>(CVarTypeRs_e::String);
+        case SOURCESDK::CS2::EConVarType_Color:
+            return static_cast<int16_t>(CVarTypeRs_e::Color);
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            return static_cast<int16_t>(CVarTypeRs_e::Vector2);
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            return static_cast<int16_t>(CVarTypeRs_e::Vector3);
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            return static_cast<int16_t>(CVarTypeRs_e::Vector4);
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            return static_cast<int16_t>(CVarTypeRs_e::Qangle);
+        }
+    }
+    return static_cast<int16_t>(CVarTypeRs_e::Invalid);
+}
+
+enum class CVarGetMode_e : int8_t {
+    Value = 0,
+    DefaultValue = 1,
+    MinValue = 2,
+    MaxValue = 3
+};
+
+SOURCESDK::CS2::CVValue_t * GetCvarValue(CVarRs_t * p_cvar, CVarGetMode_e mode) {
+    if(p_cvar) {
+        switch(mode) {
+        case CVarGetMode_e::Value:
+            return &(p_cvar->m_Value);
+        case CVarGetMode_e::DefaultValue:
+            return p_cvar->m_defaultValue;
+        case CVarGetMode_e::MinValue:
+            return p_cvar->m_minValue;
+        case CVarGetMode_e::MaxValue:
+            return p_cvar->m_maxValue;
+        }
+    }
+    return nullptr;
+}
+
+extern "C" FFIBool afx_hook_source2_get_convar_bool(CVarRs_t * p_cvar, CVarGetMode_e mode, FFIBool & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            outValue = BOOL_TO_FFIBOOL(p_value->m_bValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            outValue = BOOL_TO_FFIBOOL(0 != p_value->m_i16Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            outValue = BOOL_TO_FFIBOOL(0 != p_value->m_u16Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            outValue = BOOL_TO_FFIBOOL(0 != p_value->m_i32Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            outValue = BOOL_TO_FFIBOOL(0 != p_value->m_u32Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            outValue = BOOL_TO_FFIBOOL(0 != p_value->m_i64Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            outValue = BOOL_TO_FFIBOOL(0 != p_value->m_u64Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            outValue = BOOL_TO_FFIBOOL(0 != p_value->m_flValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            outValue = BOOL_TO_FFIBOOL(0 != p_value->m_dbValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_bool(CVarRs_t * p_cvar, CVarGetMode_e mode, FFIBool value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            p_value->m_bValue = FFIBOOL_TO_BOOL(value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            p_value->m_i16Value = FFIBOOL_TO_BOOL(value) ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            p_value->m_u16Value = FFIBOOL_TO_BOOL(value) ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            p_value->m_i32Value = FFIBOOL_TO_BOOL(value) ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            p_value->m_u32Value = FFIBOOL_TO_BOOL(value) ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            p_value->m_i64Value = FFIBOOL_TO_BOOL(value) ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            p_value->m_u64Value = FFIBOOL_TO_BOOL(value) ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            p_value->m_flValue = FFIBOOL_TO_BOOL(value) ? 1.0f : 0.0f;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            p_value->m_dbValue = FFIBOOL_TO_BOOL(value) ? 1.0 : 0.0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_get_convar_int(CVarRs_t * p_cvar, CVarGetMode_e mode, signed int & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            outValue = p_value->m_bValue ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            outValue = p_value->m_i16Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            outValue = (signed int)(p_value->m_u16Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            outValue = p_value->m_i32Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            outValue = (signed int)(p_value->m_u32Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            outValue = (signed int)(p_value->m_i64Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            outValue = (signed int)(p_value->m_u64Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            outValue = (signed int)(p_value->m_flValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            outValue = (signed int)(p_value->m_dbValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_int(CVarRs_t * p_cvar, CVarGetMode_e mode, signed int value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            p_value->m_bValue = 0 != value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            p_value->m_i16Value = (signed short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            p_value->m_u16Value = (unsigned short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            p_value->m_i32Value = (signed int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            p_value->m_u32Value = (unsigned int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            p_value->m_i64Value = value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            p_value->m_u64Value = (uint64_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            p_value->m_flValue = (float)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            p_value->m_dbValue = (double)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_get_convar_int64(CVarRs_t * p_cvar, CVarGetMode_e mode, int64_t & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            outValue = p_value->m_bValue ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            outValue = p_value->m_i16Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            outValue = (int64_t)(p_value->m_u16Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            outValue = p_value->m_i32Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            outValue = (int64_t)(p_value->m_u32Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            outValue = p_value->m_i64Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            outValue = (int64_t)(p_value->m_u64Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            outValue = (int64_t)(p_value->m_flValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            outValue = (int64_t)(p_value->m_dbValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_int64(CVarRs_t * p_cvar, CVarGetMode_e mode, int64_t value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            p_value->m_bValue = 0 != value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            p_value->m_i16Value = (signed short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            p_value->m_u16Value = (unsigned short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            p_value->m_i32Value = (signed int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            p_value->m_u32Value = (unsigned int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            p_value->m_i64Value = value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            p_value->m_u64Value = (uint64_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            p_value->m_flValue = (float)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            p_value->m_dbValue = (double)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_get_convar_uint(CVarRs_t * p_cvar, CVarGetMode_e mode, unsigned int & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            outValue = p_value->m_bValue ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            outValue = (unsigned int)(p_value->m_i16Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            outValue = p_value->m_u16Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            outValue = (unsigned int)(p_value->m_i32Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            outValue = p_value->m_u32Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            outValue = (unsigned int)p_value->m_i64Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            outValue = (unsigned int)p_value->m_u64Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            outValue = (unsigned int)p_value->m_flValue;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            outValue = (unsigned int)p_value->m_dbValue;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_uint(CVarRs_t * p_cvar, CVarGetMode_e mode, unsigned int value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            p_value->m_bValue = 0 != value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            p_value->m_i16Value = (signed short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            p_value->m_u16Value = (unsigned short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            p_value->m_i32Value = (signed int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            p_value->m_u32Value = (unsigned short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            p_value->m_i64Value = (int64_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            p_value->m_u64Value = (uint64_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            p_value->m_flValue = (float)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            p_value->m_dbValue = (double)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_get_convar_uint64(CVarRs_t * p_cvar, CVarGetMode_e mode, uint64_t & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            outValue = p_value->m_bValue ? 1 : 0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            outValue = (uint64_t)(p_value->m_i16Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            outValue = p_value->m_u16Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            outValue = (uint64_t)(p_value->m_i32Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            outValue = p_value->m_u32Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            outValue = (uint64_t)(p_value->m_i64Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            outValue = p_value->m_u64Value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            outValue = (uint64_t)(p_value->m_flValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            outValue = (uint64_t)(p_value->m_dbValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_uint64(CVarRs_t * p_cvar, CVarGetMode_e mode, uint64_t value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            p_value->m_bValue = 0 != value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            p_value->m_i16Value = (signed short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            p_value->m_u16Value = (unsigned short int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            p_value->m_i32Value = (signed int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            p_value->m_u32Value = (unsigned int)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            p_value->m_i64Value = (int64_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            p_value->m_u64Value = value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            p_value->m_flValue = (float)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            p_value->m_dbValue = (double)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_get_convar_double(CVarRs_t * p_cvar, CVarGetMode_e mode, double & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            outValue = p_value->m_bValue ? 1.0 : 0.0;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            outValue = (double)(p_value->m_i16Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            outValue = (double)(p_value->m_u16Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            outValue = (double)(p_value->m_i32Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            outValue = (double)(p_value->m_u32Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            outValue = (double)(p_value->m_i64Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            outValue = (double)(p_value->m_u64Value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            outValue = (double)(p_value->m_flValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            outValue = (double)(p_value->m_dbValue);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_double(CVarRs_t * p_cvar, CVarGetMode_e mode, double value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            p_value->m_bValue = 0 != value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int16:
+            p_value->m_i16Value = (int16_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            p_value->m_u16Value = (uint16_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int32:
+            p_value->m_i32Value = (int32_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            p_value->m_u32Value = (uint32_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Int64:
+            p_value->m_i64Value = (int64_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            p_value->m_u64Value = (uint64_t)value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float32:
+            p_value->m_flValue = (float)value;;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Float64:
+            p_value->m_dbValue = value;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_get_convar_string(CVarRs_t * p_cvar, CVarGetMode_e mode, const char * & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            outValue = p_value->m_szValue.Get();
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_string(CVarRs_t * p_cvar, CVarGetMode_e mode, const char * value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            p_value->m_szValue.Set(value);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+
+struct AfxHookSource2RsColor {
+    unsigned char r;
+    unsigned char g;
+    unsigned char b;
+    unsigned char a;
+};
+
+extern "C" FFIBool afx_hook_source2_get_convar_color(CVarRs_t * p_cvar, CVarGetMode_e mode, AfxHookSource2RsColor & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            outValue.r = p_value->m_clrValue.r();
+            outValue.g = p_value->m_clrValue.g();
+            outValue.b = p_value->m_clrValue.b();
+            outValue.a = p_value->m_clrValue.a();
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_color(CVarRs_t * p_cvar, CVarGetMode_e mode, const AfxHookSource2RsColor & value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            p_value->m_clrValue.SetColor(value.r,value.g,value.b,value.a);
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+struct AfxHookSource2RsVec2{
+    float x;
+    float y;
+};
+
+extern "C" FFIBool afx_hook_source2_get_convar_vec2(CVarRs_t * p_cvar, CVarGetMode_e mode, AfxHookSource2RsVec2 & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            outValue.x = p_value->m_vec2Value.x;
+            outValue.y = p_value->m_vec2Value.y;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_vec2(CVarRs_t * p_cvar, CVarGetMode_e mode, const AfxHookSource2RsVec2 & value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            p_value->m_vec2Value.x = value.x;
+            p_value->m_vec2Value.y = value.y;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+struct AfxHookSource2RsVec3 {
+    float x;
+    float y;
+    float z;
+};
+
+extern "C" FFIBool afx_hook_source2_get_convar_vec3(CVarRs_t * p_cvar, CVarGetMode_e mode, AfxHookSource2RsVec3 & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            outValue.x = p_value->m_vec3Value.x;
+            outValue.y = p_value->m_vec3Value.y;
+            outValue.z = p_value->m_vec3Value.z;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_vec3(CVarRs_t * p_cvar, CVarGetMode_e mode, const AfxHookSource2RsVec3 & value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            p_value->m_vec3Value.x = value.x;
+            p_value->m_vec3Value.y = value.y;
+            p_value->m_vec3Value.z = value.z;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+struct AfxHookSource2RsVec4 {
+    float x;
+    float y;
+    float z;
+    float w;
+};
+
+extern "C" FFIBool afx_hook_source2_get_convar_vec4(CVarRs_t * p_cvar, CVarGetMode_e mode, AfxHookSource2RsVec4 & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            outValue.x = p_value->m_vec4Value.x;
+            outValue.y = p_value->m_vec4Value.y;
+            outValue.z = p_value->m_vec4Value.z;
+            outValue.w = p_value->m_vec4Value.w;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_vec4(CVarRs_t * p_cvar, CVarGetMode_e mode, const AfxHookSource2RsVec4 & value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            p_value->m_vec4Value.x = value.x;
+            p_value->m_vec4Value.y = value.y;
+            p_value->m_vec4Value.z = value.z;
+            p_value->m_vec4Value.w = value.w;
+            return FFIBOOL_TRUE;
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            break; // undefined
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+struct AfxHookSource2RsQangle {
+    float x;
+    float y;
+    float z;
+};
+
+extern "C" FFIBool afx_hook_source2_get_convar_qangle(CVarRs_t * p_cvar, CVarGetMode_e mode, AfxHookSource2RsQangle & outValue) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            outValue.x = p_value->m_angValue.x;
+            outValue.y = p_value->m_angValue.y;
+            outValue.z = p_value->m_angValue.z;
+            return FFIBOOL_TRUE;
+        }
+    }
+    return FFIBOOL_FALSE;
+}
+
+extern "C" FFIBool afx_hook_source2_set_convar_qangle(CVarRs_t * p_cvar, CVarGetMode_e mode, const AfxHookSource2RsQangle & value) {
+    if(SOURCESDK::CS2::CVValue_t *p_value = GetCvarValue(p_cvar, mode)) {
+        switch(p_cvar->m_eVarType) {
+        case SOURCESDK::CS2::EConVarType_Bool:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt16:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Int64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_UInt64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float32:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Float64:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_String:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Color:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector2:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector3:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Vector4:
+            break; // undefined
+        case SOURCESDK::CS2::EConVarType_Qangle:
+            p_value->m_angValue.x = value.x;
+            p_value->m_angValue.y = value.y;
+            p_value->m_angValue.z = value.z;
+            return FFIBOOL_TRUE;
+        }
+    }
+    return FFIBOOL_FALSE;
+}

--- a/AfxHookSource2Rs/src/advancedfx/cvar/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/cvar/mod.rs
@@ -1,0 +1,214 @@
+use std::ffi::c_char;
+use std::ffi::c_void;
+
+pub type CVar = c_void;
+
+#[repr(i16)]
+pub enum CVarType {
+	Invalid = -1,
+	Bool = 0,
+	Int16 = 1,
+	UInt16 = 2,
+	Int32 = 3,
+	UInt32 = 4,
+	Int64 = 5,
+	UInt64 = 6,
+	Float32 = 7,
+	Float64 = 8,
+	String = 9,
+	Color = 10,
+	Vector2 = 11,
+	Vector3 = 12,
+	Vector4 = 13,
+	Qangle = 14    
+}
+
+impl std::convert::From<i16> for CVarType {
+    fn from(item: i16) -> Self {
+       match item {
+        0 => {
+            CVarType::Bool
+        },
+        1 => {
+            CVarType::Int16
+        },
+        2 => {
+            CVarType::UInt16
+        },
+        3 => {
+            CVarType::Int32
+        },
+        4 => {
+            CVarType::UInt32
+        },
+        5 => {
+            CVarType::Int64
+        },
+        6 => {
+            CVarType::UInt64
+        },
+        7 => {
+            CVarType::Float32
+        },
+        8 => {
+            CVarType::Float64
+        },
+        9 => {
+            CVarType::String
+        },
+        10 => {
+            CVarType::Color
+        },
+        11 => {
+            CVarType::Vector2
+        },
+        12 => {
+            CVarType::Vector3
+        },
+        13 => {
+            CVarType::Vector4
+        },
+        14 => {
+            CVarType::Qangle
+        },
+        _ => {
+            CVarType::Invalid
+        }
+       }
+    }
+}
+
+unsafe fn i16_to_cvar_type(value: i16) -> CVarType {
+    unsafe { std::mem::transmute(value) }
+}
+
+
+#[repr(i8)]
+pub enum CVarGetMode {
+    Value = 0,
+    DefaultValue = 1,
+    MinValue = 2,
+    MaxValue = 3    
+}
+
+impl std::convert::From<i8> for CVarGetMode {
+    fn from(item: i8) -> Self {
+       match item {
+        1 => {
+            CVarGetMode::DefaultValue
+        },
+        2 => {
+            CVarGetMode::MinValue
+        },
+        3 => {
+            CVarGetMode::MaxValue
+        },
+        _ => {
+            CVarGetMode::Value
+        }
+       }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Vector2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Vector3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Vector4 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct QAngle {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+extern "C" {
+    pub(crate) fn afx_hook_source2_find_convar_index(psz_name: *const c_char) -> usize;
+
+    pub(crate) fn afx_hook_source2_is_convar_index_valid(index: usize) -> bool;
+    
+    pub(crate) fn afx_hook_source2_get_convar(index: usize) -> * mut CVar;
+
+    pub(crate) fn afx_hook_source2_get_convar_type(p_cvar:  * mut CVar) -> i16;
+
+    pub(crate) fn afx_hook_source2_get_convar_bool(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut bool) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_bool(p_cvar:  * mut CVar, mode: i8, value: bool) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_int(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut i32) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_int(p_cvar:  * mut CVar, mode: i8, value: i32) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_int64(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut i64) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_int64(p_cvar:  * mut CVar, mode: i8, value: i64) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_uint(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut u32) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_uint(p_cvar:  * mut CVar, mode: i8, value : u32) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_uint64(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut u64) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_uint64(p_cvar:  * mut CVar, mode: i8, value : u64) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_double(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut f64) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_double(p_cvar:  * mut CVar, mode: i8, value : f64) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_string(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut *const c_char) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_string(p_cvar:  * mut CVar, mode: i8, value : * const c_char) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_color(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut Color) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_color(p_cvar:  * mut CVar, mode: i8, value : * const Color) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_vec2(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut Vector2) -> bool;
+    
+    // pub(crate) fn afx_hook_source2_set_convar_vec2(p_cvar:  * mut CVar, mode: i8, value : * const Vector2) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_vec3(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut Vector3) -> bool;
+    
+    // pub(crate) fn afx_hook_source2_set_convar_vec3(p_cvar:  * mut CVar, mode: i8, value : * const Vector3) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_vec4(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut Vector4) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_vec4(p_cvar:  * mut CVar, mode: i8, value : * const Vector4) -> bool;
+
+    pub(crate) fn afx_hook_source2_get_convar_qangle(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut QAngle) -> bool;
+
+    // pub(crate) fn afx_hook_source2_set_convar_qangle(p_cvar:  * mut CVar, mode: i8, value : * const QAngle) -> bool;
+}
+
+pub(crate) fn afx_get_convar_type(p_cvar:  * mut CVar) -> CVarType {
+    return unsafe { i16_to_cvar_type( afx_hook_source2_get_convar_type(p_cvar) ) };
+}

--- a/AfxHookSource2Rs/src/advancedfx/cvar/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/cvar/mod.rs
@@ -25,56 +25,56 @@ pub enum CVarType {
 
 impl std::convert::From<i16> for CVarType {
     fn from(item: i16) -> Self {
-       match item {
-        0 => {
-            CVarType::Bool
-        },
-        1 => {
-            CVarType::Int16
-        },
-        2 => {
-            CVarType::UInt16
-        },
-        3 => {
-            CVarType::Int32
-        },
-        4 => {
-            CVarType::UInt32
-        },
-        5 => {
-            CVarType::Int64
-        },
-        6 => {
-            CVarType::UInt64
-        },
-        7 => {
-            CVarType::Float32
-        },
-        8 => {
-            CVarType::Float64
-        },
-        9 => {
-            CVarType::String
-        },
-        10 => {
-            CVarType::Color
-        },
-        11 => {
-            CVarType::Vector2
-        },
-        12 => {
-            CVarType::Vector3
-        },
-        13 => {
-            CVarType::Vector4
-        },
-        14 => {
-            CVarType::Qangle
-        },
-        _ => {
-            CVarType::Invalid
+        match item {
+            0 => {
+                CVarType::Bool
+            },
+            1 => {
+                CVarType::Int16
+            },
+            2 => {
+               CVarType::UInt16
+            },
+            3 => {
+                CVarType::Int32
+            },
+            4 => {
+                CVarType::UInt32
+            },
+            5 => {
+                CVarType::Int64
+            },
+            6 => {
+                CVarType::UInt64
+            },
+            7 => {
+                CVarType::Float32
+            },
+            8 => {
+                CVarType::Float64
+            },
+            9 => {
+                CVarType::String
+            },
+            10 => {
+                CVarType::Color
+            },
+            11 => {
+                CVarType::Vector2
+            },
+            12 => {
+                CVarType::Vector3
+            },
+            13 => {
+                CVarType::Vector4
+            },
+            14 => {
+                CVarType::Qangle
+            },
+            _ => {
+                CVarType::Invalid
+            }
         }
-       }
     }
 }
 
@@ -88,25 +88,25 @@ pub enum CVarGetMode {
     Value = 0,
     DefaultValue = 1,
     MinValue = 2,
-    MaxValue = 3    
+    MaxValue = 3
 }
 
 impl std::convert::From<i8> for CVarGetMode {
     fn from(item: i8) -> Self {
-       match item {
-        1 => {
-            CVarGetMode::DefaultValue
-        },
-        2 => {
-            CVarGetMode::MinValue
-        },
-        3 => {
-            CVarGetMode::MaxValue
-        },
-        _ => {
-            CVarGetMode::Value
+        match item {
+            1 => {
+                CVarGetMode::DefaultValue
+            },
+            2 => {
+                CVarGetMode::MinValue
+            },
+            3 => {
+                CVarGetMode::MaxValue
+            },
+            _ => {
+                CVarGetMode::Value
+            }
         }
-       }
     }
 }
 

--- a/AfxHookSource2Rs/src/advancedfx/cvar/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/cvar/mod.rs
@@ -160,53 +160,57 @@ extern "C" {
 
     pub(crate) fn afx_hook_source2_get_convar_type(p_cvar:  * mut CVar) -> i16;
 
+    pub(crate) fn afx_hook_source2_get_convar_name(p_cvar:  * mut CVar, p_out_value: &mut *const c_char) -> bool;
+
+    pub(crate) fn  afx_hook_source2_get_convar_help_string(p_cvar:  * mut CVar, p_out_value: &mut *const c_char) -> bool;
+
     pub(crate) fn afx_hook_source2_get_convar_bool(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut bool) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_bool(p_cvar:  * mut CVar, mode: i8, value: bool) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_bool(p_cvar:  * mut CVar, mode: i8, value: bool) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_int(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut i32) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_int(p_cvar:  * mut CVar, mode: i8, value: i32) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_int(p_cvar:  * mut CVar, mode: i8, value: i32) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_int64(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut i64) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_int64(p_cvar:  * mut CVar, mode: i8, value: i64) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_int64(p_cvar:  * mut CVar, mode: i8, value: i64) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_uint(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut u32) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_uint(p_cvar:  * mut CVar, mode: i8, value : u32) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_uint(p_cvar:  * mut CVar, mode: i8, value : u32) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_uint64(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut u64) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_uint64(p_cvar:  * mut CVar, mode: i8, value : u64) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_uint64(p_cvar:  * mut CVar, mode: i8, value : u64) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_double(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut f64) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_double(p_cvar:  * mut CVar, mode: i8, value : f64) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_double(p_cvar:  * mut CVar, mode: i8, value : f64) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_string(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut *const c_char) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_string(p_cvar:  * mut CVar, mode: i8, value : * const c_char) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_string(p_cvar:  * mut CVar, mode: i8, value : * const c_char) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_color(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut Color) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_color(p_cvar:  * mut CVar, mode: i8, value : * const Color) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_color(p_cvar:  * mut CVar, mode: i8, value : * const Color) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_vec2(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut Vector2) -> bool;
     
-    // pub(crate) fn afx_hook_source2_set_convar_vec2(p_cvar:  * mut CVar, mode: i8, value : * const Vector2) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_vec2(p_cvar:  * mut CVar, mode: i8, value : * const Vector2) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_vec3(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut Vector3) -> bool;
     
-    // pub(crate) fn afx_hook_source2_set_convar_vec3(p_cvar:  * mut CVar, mode: i8, value : * const Vector3) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_vec3(p_cvar:  * mut CVar, mode: i8, value : * const Vector3) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_vec4(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut Vector4) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_vec4(p_cvar:  * mut CVar, mode: i8, value : * const Vector4) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_vec4(p_cvar:  * mut CVar, mode: i8, value : * const Vector4) -> bool;
 
     pub(crate) fn afx_hook_source2_get_convar_qangle(p_cvar:  * mut CVar, mode: i8, p_out_value: &mut QAngle) -> bool;
 
-    // pub(crate) fn afx_hook_source2_set_convar_qangle(p_cvar:  * mut CVar, mode: i8, value : * const QAngle) -> bool;
+    pub(crate) fn afx_hook_source2_set_convar_qangle(p_cvar:  * mut CVar, mode: i8, value : * const QAngle) -> bool;
 }
 
 pub(crate) fn afx_get_convar_type(p_cvar:  * mut CVar) -> CVarType {

--- a/AfxHookSource2Rs/src/advancedfx/cvar/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/cvar/mod.rs
@@ -153,8 +153,6 @@ pub struct QAngle {
 
 extern "C" {
     pub(crate) fn afx_hook_source2_find_convar_index(psz_name: *const c_char) -> usize;
-
-    pub(crate) fn afx_hook_source2_is_convar_index_valid(index: usize) -> bool;
     
     pub(crate) fn afx_hook_source2_get_convar(index: usize) -> * mut CVar;
 

--- a/AfxHookSource2Rs/src/advancedfx/js/cvar/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/js/cvar/mod.rs
@@ -1,0 +1,277 @@
+use crate::advancedfx;
+
+use std::ffi::c_char;
+use core::ffi::CStr;
+
+use boa_engine::{
+    class::{
+        Class,
+        ClassBuilder,
+    },
+    property::Attribute,
+    js_string,
+    Context,
+    Finalize,
+    JsData,
+    JsNativeError,
+    JsResult,
+    JsValue,
+    NativeFunction,
+    object::builtins::{
+        JsFloat32Array,
+        JsUint8Array
+    },
+
+    Trace
+};
+
+#[derive(Trace, Finalize, JsData)]
+pub struct CVar {
+    #[unsafe_ignore_trace]
+    pub native: * mut advancedfx::cvar::CVar
+}
+
+impl CVar {
+    #[must_use]
+    pub fn new(native: * mut advancedfx::cvar::CVar) -> Self {        
+        Self {
+            native: native
+        }
+    }
+
+    pub fn add_to_context(context: &mut Context) {
+        context
+            .register_global_class::<CVar>()
+            .expect("the AdvancedfxCVar builtin shouldn't exist");        
+    }
+
+    fn error_typ(context: &Context) -> JsResult<JsValue> {
+        Err(advancedfx::js::errors::make_error!(JsNativeError::typ(), "'this' is not a AdvancedfxCVar object", context).into())
+    }
+
+
+    fn is_valid_index(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        if 1 == args.len() {
+            if let JsValue::Integer(index) = args[0] {
+                let result = unsafe {advancedfx::cvar::afx_hook_source2_is_convar_index_valid(index as usize)};
+                return Ok(JsValue::Boolean(result));
+            }
+        }
+        Err(advancedfx::js::errors::error_arguments(context).into())
+    }
+
+    fn get_value_ex(this: &JsValue, context: &mut Context, get_mode: advancedfx::cvar::CVarGetMode) -> JsResult<JsValue> {
+        if let Some(object) = this.as_object() {
+            if let Some(object_inner) = object.downcast_ref::<CVar>() {
+                let p_cvar = object_inner.native;
+                let get_mode_i8 = get_mode as i8;
+                let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
+                match cvar_type {
+                    advancedfx::cvar::CVarType::Invalid => {
+                        return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"invalid cvar type", context).into());
+                    }
+                    advancedfx::cvar::CVarType::Bool => {
+                        let mut result : bool = false;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_bool(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::Boolean(result));
+                        }
+                    }
+                    advancedfx::cvar::CVarType::Int16 => {
+                        let mut result : i32 = 0;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::Integer(result));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::UInt16 => {
+                        let mut result : u32 = 0;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::Integer(result as i32));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::Int32 => {
+                        let mut result : i32 = 0;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::Integer(result));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::UInt32 => {
+                        let mut result : u32 = 0;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::Integer(result as i32));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::Int64 => {
+                        let mut result : i64 = 0;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int64(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::BigInt(result.into()));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::UInt64 => {
+                        let mut result : u64 = 0;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint64(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::BigInt(result.into()));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::Float32 => {
+                        let mut result : f64 = 0.0;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_double(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::Rational(result));
+                        }                      
+                    }
+                    advancedfx::cvar::CVarType::Float64 => {
+                        let mut result : f64 = 0.0;
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_double(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::Rational(result));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::String => {
+                        let mut result: *const c_char = std::ptr::null();
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_string(p_cvar,get_mode_i8,&mut result)} {
+                            return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::Color => {
+                        let mut result = advancedfx::cvar::Color{r:0,g:0,b:0,a:0};
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_color(p_cvar,get_mode_i8,&mut result)} {
+                            let array = JsUint8Array::from_iter(vec![result.r, result.g, result.b, result.a], context)?;
+                            return Ok(JsValue::Object(array.into()));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::Vector2 => {
+                        let mut result = advancedfx::cvar::Vector2{x:0.0,y:0.0};
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec2(p_cvar,get_mode_i8,&mut result)} {
+                            let array = JsFloat32Array::from_iter(vec![result.x, result.y], context)?;
+                            return Ok(JsValue::Object(array.into()));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::Vector3 => {
+                        let mut result = advancedfx::cvar::Vector3{x:0.0,y:0.0,z:0.0};
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec3(p_cvar,get_mode_i8,&mut result)} {
+                            let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z], context)?;
+                            return Ok(JsValue::Object(array.into()));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::Vector4 => {
+                        let mut result = advancedfx::cvar::Vector4{x:0.0,y:0.0,z:0.0,w:0.0};
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec4(p_cvar,get_mode_i8,&mut result)} {
+                            let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z,result.w], context)?;
+                            return Ok(JsValue::Object(array.into()));
+                        }                        
+                    }
+                    advancedfx::cvar::CVarType::Qangle => {
+                        let mut result = advancedfx::cvar::QAngle{x:0.0,y:0.0,z:0.0};
+                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_qangle(p_cvar,get_mode_i8,&mut result)} {
+                            let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z], context)?;
+                            return Ok(JsValue::Object(array.into()));
+                        }                        
+                    }
+                }
+                return Ok(JsValue::Undefined);
+            }
+        }
+        Self::error_typ(context)        
+    }
+
+    fn get_value(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        return Self::get_value_ex(this, context, advancedfx::cvar::CVarGetMode::Value);
+    }   
+    fn get_default_value(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        return Self::get_value_ex(this, context, advancedfx::cvar::CVarGetMode::DefaultValue);
+    }   
+    fn get_min_value(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        return Self::get_value_ex(this, context, advancedfx::cvar::CVarGetMode::MinValue);
+    }   
+    fn get_max_value(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        return Self::get_value_ex(this, context, advancedfx::cvar::CVarGetMode::MaxValue);
+    } 
+
+    fn get_type(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        if let Some(object) = this.as_object() {
+            if let Some(object_inner) = object.downcast_ref::<CVar>() {
+                let p_cvar = object_inner.native;
+                let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
+                return Ok(JsValue::Integer(cvar_type as i32))
+            }
+        }
+        Self::error_typ(context)
+    }  
+}
+
+impl Class for CVar {
+    const NAME: &'static str = "AdvancedfxCVar";
+    const LENGTH: usize = 3;
+
+    fn data_constructor(
+        _this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<Self> {
+        if 1 == args.len() {
+            match &args[0] {
+                JsValue::String(js_string) => {
+                    let c_string = std::ffi::CString::new(js_string.to_std_string_escaped()).unwrap();
+                    let index = unsafe { advancedfx::cvar::afx_hook_source2_find_convar_index(c_string.as_ptr()) };
+                    let cvar = unsafe { advancedfx::cvar::afx_hook_source2_get_convar(index) };
+                    if cvar.is_null() {
+                        return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"not a valid cvar", context).into());
+                    }
+                    return Ok(CVar::new(cvar));
+                }
+                JsValue::Integer(index) => {
+                    let cvar = unsafe { advancedfx::cvar::afx_hook_source2_get_convar(*index as usize) };
+                    if cvar.is_null() {
+                        return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"not a valid cvar", context).into());
+                    }
+                    return Ok(CVar::new(cvar));                
+                }
+                _=> {
+
+                }
+            }
+        }
+        Err(advancedfx::js::errors::error_arguments(context).into())
+    }
+
+    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {
+        let realm = class.context().realm().clone();
+        class
+            .static_method(
+                js_string!("isValidIndex"),
+                1,
+                NativeFunction::from_fn_ptr(CVar::is_valid_index),
+            )
+            .accessor(
+                js_string!("value"),
+                Some(NativeFunction::from_fn_ptr(CVar::get_value).to_js_function(&realm)),
+                None,
+                Attribute::all()
+            )
+            .accessor(
+                js_string!("defaultValue"),
+                Some(NativeFunction::from_fn_ptr(CVar::get_default_value).to_js_function(&realm)),
+                None,
+                Attribute::all()
+            )
+            .accessor(
+                js_string!("minValue"),
+                Some(NativeFunction::from_fn_ptr(CVar::get_min_value).to_js_function(&realm)),
+                None,
+                Attribute::all()
+            )
+            .accessor(
+                js_string!("maxValue"),
+                Some(NativeFunction::from_fn_ptr(CVar::get_max_value).to_js_function(&realm)),
+                None,
+                Attribute::all()
+            )
+            .method(
+                js_string!("getType"),
+                1,
+                NativeFunction::from_fn_ptr(CVar::get_type),
+            )
+        ;
+        Ok(())
+    }
+}
+
+

--- a/AfxHookSource2Rs/src/advancedfx/js/cvar/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/js/cvar/mod.rs
@@ -13,6 +13,7 @@ use boa_engine::{
     Context,
     Finalize,
     JsData,
+    JsError,
     JsNativeError,
     JsResult,
     JsValue,
@@ -172,6 +173,180 @@ impl CVar {
         Self::error_typ(context)        
     }
 
+    fn set_value_error(context: &mut Context) -> JsError {
+        return advancedfx::js::errors::make_error!(JsNativeError::error(),"could not set cvar value", context).into();
+    }
+
+    fn set_value_ex(this: &JsValue, args: &[JsValue], context: &mut Context, get_mode: advancedfx::cvar::CVarGetMode) -> JsResult<JsValue> {
+        if let Some(object) = this.as_object() {
+            if let Some(object_inner) = object.downcast_ref::<CVar>() {
+                if 1 == args.len() {
+                    let p_cvar = object_inner.native;
+                    let get_mode_i8 = get_mode as i8;
+                    let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
+                    let arg0 = &args[0];
+                    match cvar_type {
+                        advancedfx::cvar::CVarType::Invalid => {
+                            return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"invalid cvar type", context).into());
+                        }
+                        advancedfx::cvar::CVarType::Bool => {
+                           let value = arg0.to_boolean();
+                            if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_bool(p_cvar, get_mode_i8, value)} {
+                                return Err(Self::set_value_error(context));
+                            }
+                            return Ok(JsValue::Undefined);                                
+                        }
+                        advancedfx::cvar::CVarType::Int16 => {
+                            if let Ok(value) = arg0.to_int16(context) {
+                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int(p_cvar, get_mode_i8, value as i32)} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);                                
+                            }
+                        }
+                        advancedfx::cvar::CVarType::UInt16 => {
+                            if let Ok(value) = arg0.to_uint16(context) {
+                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint(p_cvar, get_mode_i8, value as u32)} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);                                
+                            }
+                        }
+                        advancedfx::cvar::CVarType::Int32 => {
+                            if let Ok(value) = arg0.to_i32(context) {
+                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int(p_cvar, get_mode_i8, value)} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);                                
+                            }
+                        }
+                        advancedfx::cvar::CVarType::UInt32 => {
+                            if let Ok(value) = arg0.to_u32(context) {
+                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint(p_cvar, get_mode_i8, value)} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);                                
+                            }
+                        }
+                        advancedfx::cvar::CVarType::Int64 => {
+                            if let Ok(value) = arg0.to_big_int64(context) {
+                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int64(p_cvar, get_mode_i8, value)} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);                                
+                            }
+                        }
+                        advancedfx::cvar::CVarType::UInt64 => {
+                            if let Ok(value) = arg0.to_big_uint64(context) {
+                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint64(p_cvar, get_mode_i8, value)} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);                                
+                            }                       
+                        }
+                        advancedfx::cvar::CVarType::Float32 => {
+                            if let Ok(value) = arg0.to_f32(context) {
+                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_double(p_cvar, get_mode_i8, value as f64)} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);                                
+                            }                        
+                        }
+                        advancedfx::cvar::CVarType::Float64 => {
+                            if let Ok(value) = arg0.to_number(context) {
+                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_double(p_cvar, get_mode_i8, value)} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);                                
+                            }                         
+                        }
+                        advancedfx::cvar::CVarType::String => {
+                            if let Ok(value) = arg0.to_string(context) {
+                                let c_string = std::ffi::CString::new(value.to_std_string_escaped()).unwrap();
+                                if !unsafe {advancedfx::cvar::afx_hook_source2_set_convar_string(p_cvar,get_mode_i8, c_string.as_ptr())} {
+                                    return Err(Self::set_value_error(context));
+                                }
+                                return Ok(JsValue::Undefined);
+                            }                                   
+                        }
+                        advancedfx::cvar::CVarType::Color => {
+                            if let JsValue::Object(value) = arg0 {
+                                if let Ok(array) = JsUint8Array::from_object(value.clone()) {
+                                    let vec: Vec<u8> = array.iter(context).collect();
+                                    if vec.len() == 4 {
+                                        let value = advancedfx::cvar::Color{r:vec[0],g:vec[1],b:vec[2],a:vec[3]};
+                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_color(p_cvar, get_mode_i8, &value)} {
+                                            return Err(Self::set_value_error(context));
+                                        }
+                                        return Ok(JsValue::Undefined);
+                                    }
+                                }
+                            }
+                        }
+                        advancedfx::cvar::CVarType::Vector2 => {
+                            if let JsValue::Object(value) = arg0 {
+                                if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
+                                    let vec: Vec<f32> = array.iter(context).collect();
+                                    if vec.len() == 2 {
+                                        let value = advancedfx::cvar::Vector2{x:vec[0],y:vec[1]};
+                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec2(p_cvar, get_mode_i8, &value)} {
+                                            return Err(Self::set_value_error(context));
+                                        }
+                                        return Ok(JsValue::Undefined);
+                                    }
+                                }                                
+                            }
+                        }
+                        advancedfx::cvar::CVarType::Vector3 => {
+                            if let JsValue::Object(value) = arg0 {
+                                if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
+                                    let vec: Vec<f32> = array.iter(context).collect();
+                                    if vec.len() == 3 {
+                                        let value = advancedfx::cvar::Vector3{x:vec[0],y:vec[1],z:vec[2]};
+                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec3(p_cvar, get_mode_i8, &value)} {
+                                            return Err(Self::set_value_error(context));
+                                        }
+                                        return Ok(JsValue::Undefined);
+                                    }
+                                } 
+                            }
+                        }
+                        advancedfx::cvar::CVarType::Vector4 => {
+                            if let JsValue::Object(value) = arg0 {
+                                if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
+                                    let vec: Vec<f32> = array.iter(context).collect();
+                                    if vec.len() == 4 {
+                                        let value = advancedfx::cvar::Vector4{x:vec[0],y:vec[1],z:vec[2],w:vec[3]};
+                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec4(p_cvar, get_mode_i8, &value)} {
+                                            return Err(Self::set_value_error(context));
+                                        }
+                                        return Ok(JsValue::Undefined);
+                                    }
+                                } 
+                            }
+                        }
+                        advancedfx::cvar::CVarType::Qangle => {
+                            if let JsValue::Object(value) = arg0 {
+                                if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
+                                    let vec: Vec<f32> = array.iter(context).collect();
+                                    if vec.len() == 3 {
+                                        let value = advancedfx::cvar::QAngle{x:vec[0],y:vec[1],z:vec[2]};
+                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_qangle(p_cvar, get_mode_i8, &value)} {
+                                            return Err(Self::set_value_error(context));
+                                        }
+                                        return Ok(JsValue::Undefined);
+                                    }
+                                }    
+                            }
+                        }
+                    }
+                }
+                return Err(advancedfx::js::errors::error_arguments(context).into())
+            }
+        }
+        Self::error_typ(context)        
+    }
+
     fn get_value(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         return Self::get_value_ex(this, context, advancedfx::cvar::CVarGetMode::Value);
     }   
@@ -185,6 +360,10 @@ impl CVar {
         return Self::get_value_ex(this, context, advancedfx::cvar::CVarGetMode::MaxValue);
     } 
 
+    fn set_value(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        return Self::set_value_ex(this, args, context, advancedfx::cvar::CVarGetMode::Value);
+    }   
+
     fn get_type(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         if let Some(object) = this.as_object() {
             if let Some(object_inner) = object.downcast_ref::<CVar>() {
@@ -194,7 +373,38 @@ impl CVar {
             }
         }
         Self::error_typ(context)
-    }  
+    }
+
+    fn get_name(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        if let Some(object) = this.as_object() {
+            if let Some(object_inner) = object.downcast_ref::<CVar>() {
+                let p_cvar = object_inner.native;
+                let mut result: *const c_char = std::ptr::null();
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_name(p_cvar,&mut result)} {
+                    if !result.is_null() {
+                        return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
+                    }
+                }
+                return Ok(JsValue::Undefined); // This probably will never happen, just here in case.
+            }
+        }
+        Self::error_typ(context)
+    }
+    fn get_help_string(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        if let Some(object) = this.as_object() {
+            if let Some(object_inner) = object.downcast_ref::<CVar>() {
+                let p_cvar = object_inner.native;
+                let mut result: *const c_char = std::ptr::null();
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_help_string(p_cvar,&mut result)} {
+                    if !result.is_null() {
+                        return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
+                    }
+                }
+                return Ok(JsValue::Undefined);
+            }
+        }
+        Self::error_typ(context)
+    }
 }
 
 impl Class for CVar {
@@ -241,9 +451,21 @@ impl Class for CVar {
                 NativeFunction::from_fn_ptr(CVar::is_valid_index),
             )
             .accessor(
+                js_string!("name"),
+                Some(NativeFunction::from_fn_ptr(CVar::get_name).to_js_function(&realm)),
+                None,
+                Attribute::all()
+            )
+            .accessor(
+                js_string!("helpString"),
+                Some(NativeFunction::from_fn_ptr(CVar::get_help_string).to_js_function(&realm)),
+                None,
+                Attribute::all()
+            )
+            .accessor(
                 js_string!("value"),
                 Some(NativeFunction::from_fn_ptr(CVar::get_value).to_js_function(&realm)),
-                None,
+                Some(NativeFunction::from_fn_ptr(CVar::set_value).to_js_function(&realm)),
                 Attribute::all()
             )
             .accessor(

--- a/AfxHookSource2Rs/src/advancedfx/js/cvar/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/js/cvar/mod.rs
@@ -51,129 +51,129 @@ impl CVar {
     }
 
     fn get_index_from_name(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        if 1 == args.len() {
-            if let Ok(value) = args[0].to_string(context) {
-                let c_string = std::ffi::CString::new(value.to_std_string_escaped()).unwrap();
-                let index = unsafe {advancedfx::cvar::afx_hook_source2_find_convar_index(c_string.as_ptr())};
-                if usize::MAX == index {
-                    return Ok(JsValue::Undefined);
-                }
-                return Ok(JsValue::Integer(index as i32));
-            }      
+        if 1 != args.len() { return Err(advancedfx::js::errors::error_arguments(context).into()) };
+
+        let value = args[0].to_string(context).or_else(|_| Err(advancedfx::js::errors::error_arguments(context)))?;
+
+        let c_string = std::ffi::CString::new(value.to_std_string_escaped()).unwrap();
+        let index = unsafe {advancedfx::cvar::afx_hook_source2_find_convar_index(c_string.as_ptr())};
+        if usize::MAX == index {
+            return Ok(JsValue::Undefined);
         }
-        Err(advancedfx::js::errors::error_arguments(context).into())
+
+        Ok(JsValue::Integer(index as i32))
     }
 
     fn get_value_ex(this: &JsValue, context: &mut Context, get_mode: advancedfx::cvar::CVarGetMode) -> JsResult<JsValue> {
-        if let Some(object) = this.as_object() {
-            if let Some(object_inner) = object.downcast_ref::<CVar>() {
-                let p_cvar = object_inner.native;
-                let get_mode_i8 = get_mode as i8;
-                let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
-                match cvar_type {
-                    advancedfx::cvar::CVarType::Invalid => {
-                        return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"invalid cvar type", context).into());
-                    }
-                    advancedfx::cvar::CVarType::Bool => {
-                        let mut result : bool = false;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_bool(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::Boolean(result));
-                        }
-                    }
-                    advancedfx::cvar::CVarType::Int16 => {
-                        let mut result : i32 = 0;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::Integer(result));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::UInt16 => {
-                        let mut result : u32 = 0;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::Integer(result as i32));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::Int32 => {
-                        let mut result : i32 = 0;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::Integer(result));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::UInt32 => {
-                        let mut result : u32 = 0;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::Integer(result as i32));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::Int64 => {
-                        let mut result : i64 = 0;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int64(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::BigInt(result.into()));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::UInt64 => {
-                        let mut result : u64 = 0;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint64(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::BigInt(result.into()));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::Float32 => {
-                        let mut result : f64 = 0.0;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_double(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::Rational(result));
-                        }                      
-                    }
-                    advancedfx::cvar::CVarType::Float64 => {
-                        let mut result : f64 = 0.0;
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_double(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::Rational(result));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::String => {
-                        let mut result: *const c_char = std::ptr::null();
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_string(p_cvar,get_mode_i8,&mut result)} {
-                            return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::Color => {
-                        let mut result = advancedfx::cvar::Color{r:0,g:0,b:0,a:0};
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_color(p_cvar,get_mode_i8,&mut result)} {
-                            let array = JsUint8Array::from_iter(vec![result.r, result.g, result.b, result.a], context)?;
-                            return Ok(JsValue::Object(array.into()));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::Vector2 => {
-                        let mut result = advancedfx::cvar::Vector2{x:0.0,y:0.0};
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec2(p_cvar,get_mode_i8,&mut result)} {
-                            let array = JsFloat32Array::from_iter(vec![result.x, result.y], context)?;
-                            return Ok(JsValue::Object(array.into()));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::Vector3 => {
-                        let mut result = advancedfx::cvar::Vector3{x:0.0,y:0.0,z:0.0};
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec3(p_cvar,get_mode_i8,&mut result)} {
-                            let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z], context)?;
-                            return Ok(JsValue::Object(array.into()));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::Vector4 => {
-                        let mut result = advancedfx::cvar::Vector4{x:0.0,y:0.0,z:0.0,w:0.0};
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec4(p_cvar,get_mode_i8,&mut result)} {
-                            let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z,result.w], context)?;
-                            return Ok(JsValue::Object(array.into()));
-                        }                        
-                    }
-                    advancedfx::cvar::CVarType::Qangle => {
-                        let mut result = advancedfx::cvar::QAngle{x:0.0,y:0.0,z:0.0};
-                        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_qangle(p_cvar,get_mode_i8,&mut result)} {
-                            let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z], context)?;
-                            return Ok(JsValue::Object(array.into()));
-                        }                        
-                    }
+        let object = this.as_object().ok_or(Self::error_typ(context).unwrap_err())?;
+        let object_inner = object.downcast_ref::<CVar>().ok_or(Self::error_typ(context).unwrap_err())?;
+
+        let p_cvar = object_inner.native;
+        let get_mode_i8 = get_mode as i8;
+        let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
+
+        match cvar_type {
+            advancedfx::cvar::CVarType::Invalid => {
+                return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"invalid cvar type", context).into());
+            }
+            advancedfx::cvar::CVarType::Bool => {
+                let mut result : bool = false;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_bool(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::Boolean(result));
                 }
-                return Ok(JsValue::Undefined);
+            }
+            advancedfx::cvar::CVarType::Int16 => {
+                let mut result : i32 = 0;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::Integer(result));
+                }                        
+            }
+            advancedfx::cvar::CVarType::UInt16 => {
+                let mut result : u32 = 0;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::Integer(result as i32));
+                }                        
+            }
+            advancedfx::cvar::CVarType::Int32 => {
+                let mut result : i32 = 0;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::Integer(result));
+                }                        
+            }
+            advancedfx::cvar::CVarType::UInt32 => {
+                let mut result : u32 = 0;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::Integer(result as i32));
+                }                        
+            }
+            advancedfx::cvar::CVarType::Int64 => {
+                let mut result : i64 = 0;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_int64(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::BigInt(result.into()));
+                }                        
+            }
+            advancedfx::cvar::CVarType::UInt64 => {
+                let mut result : u64 = 0;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_uint64(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::BigInt(result.into()));
+                }                        
+            }
+            advancedfx::cvar::CVarType::Float32 => {
+                let mut result : f64 = 0.0;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_double(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::Rational(result));
+                }                      
+            }
+            advancedfx::cvar::CVarType::Float64 => {
+                let mut result : f64 = 0.0;
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_double(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::Rational(result));
+                }                        
+            }
+            advancedfx::cvar::CVarType::String => {
+                let mut result: *const c_char = std::ptr::null();
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_string(p_cvar,get_mode_i8,&mut result)} {
+                    return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
+                }                        
+            }
+            advancedfx::cvar::CVarType::Color => {
+                let mut result = advancedfx::cvar::Color{r:0,g:0,b:0,a:0};
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_color(p_cvar,get_mode_i8,&mut result)} {
+                    let array = JsUint8Array::from_iter(vec![result.r, result.g, result.b, result.a], context)?;
+                    return Ok(JsValue::Object(array.into()));
+                }                        
+            }
+            advancedfx::cvar::CVarType::Vector2 => {
+                let mut result = advancedfx::cvar::Vector2{x:0.0,y:0.0};
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec2(p_cvar,get_mode_i8,&mut result)} {
+                    let array = JsFloat32Array::from_iter(vec![result.x, result.y], context)?;
+                    return Ok(JsValue::Object(array.into()));
+                }                        
+            }
+            advancedfx::cvar::CVarType::Vector3 => {
+                let mut result = advancedfx::cvar::Vector3{x:0.0,y:0.0,z:0.0};
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec3(p_cvar,get_mode_i8,&mut result)} {
+                    let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z], context)?;
+                    return Ok(JsValue::Object(array.into()));
+                }                        
+            }
+            advancedfx::cvar::CVarType::Vector4 => {
+                let mut result = advancedfx::cvar::Vector4{x:0.0,y:0.0,z:0.0,w:0.0};
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_vec4(p_cvar,get_mode_i8,&mut result)} {
+                    let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z,result.w], context)?;
+                    return Ok(JsValue::Object(array.into()));
+                }                        
+            }
+            advancedfx::cvar::CVarType::Qangle => {
+                let mut result = advancedfx::cvar::QAngle{x:0.0,y:0.0,z:0.0};
+                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_qangle(p_cvar,get_mode_i8,&mut result)} {
+                    let array = JsFloat32Array::from_iter(vec![result.x, result.y, result.z], context)?;
+                    return Ok(JsValue::Object(array.into()));
+                }                        
             }
         }
-        Self::error_typ(context)        
+
+        Ok(JsValue::Undefined)
     }
 
     fn set_value_error(context: &mut Context) -> JsError {
@@ -181,173 +181,172 @@ impl CVar {
     }
 
     fn set_value_ex(this: &JsValue, args: &[JsValue], context: &mut Context, get_mode: advancedfx::cvar::CVarGetMode) -> JsResult<JsValue> {
-        if let Some(object) = this.as_object() {
-            if let Some(object_inner) = object.downcast_ref::<CVar>() {
-                if 1 == args.len() {
-                    let p_cvar = object_inner.native;
-                    let get_mode_i8 = get_mode as i8;
-                    let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
-                    let arg0 = &args[0];
-                    match cvar_type {
-                        advancedfx::cvar::CVarType::Invalid => {
-                            return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"invalid cvar type", context).into());
-                        }
-                        advancedfx::cvar::CVarType::Bool => {
-                           let value = arg0.to_boolean();
-                            if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_bool(p_cvar, get_mode_i8, value)} {
+        let object = this.as_object().ok_or(Self::error_typ(context).unwrap_err())?;
+        let object_inner = object.downcast_ref::<CVar>().ok_or(Self::error_typ(context).unwrap_err())?;
+        if 1 != args.len() { return Err(advancedfx::js::errors::error_arguments(context).into()) };
+
+        let p_cvar = object_inner.native;
+        let get_mode_i8 = get_mode as i8;
+        let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
+
+        let arg0 = &args[0];
+        match cvar_type {
+            advancedfx::cvar::CVarType::Invalid => {
+                return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"invalid cvar type", context).into());
+            }
+            advancedfx::cvar::CVarType::Bool => {
+               let value = arg0.to_boolean();
+               if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_bool(p_cvar, get_mode_i8, value)} {
+                   return Err(Self::set_value_error(context));
+               }
+               return Ok(JsValue::Undefined);                                
+            }
+            advancedfx::cvar::CVarType::Int16 => {
+                if let Ok(value) = arg0.to_int16(context) {
+                    if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int(p_cvar, get_mode_i8, value as i32)} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);                                
+                }
+            }
+            advancedfx::cvar::CVarType::UInt16 => {
+                if let Ok(value) = arg0.to_uint16(context) {
+                    if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint(p_cvar, get_mode_i8, value as u32)} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);                                
+                }
+            }
+            advancedfx::cvar::CVarType::Int32 => {
+                if let Ok(value) = arg0.to_i32(context) {
+                    if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int(p_cvar, get_mode_i8, value)} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);                                
+                }
+            }
+            advancedfx::cvar::CVarType::UInt32 => {
+                if let Ok(value) = arg0.to_u32(context) {
+                    if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint(p_cvar, get_mode_i8, value)} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);                                
+                }
+            }
+            advancedfx::cvar::CVarType::Int64 => {
+                if let Ok(value) = arg0.to_big_int64(context) {
+                    if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int64(p_cvar, get_mode_i8, value)} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);                                
+                }
+            }
+            advancedfx::cvar::CVarType::UInt64 => {
+                if let Ok(value) = arg0.to_big_uint64(context) {
+                    if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint64(p_cvar, get_mode_i8, value)} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);                                
+                }                       
+            }
+            advancedfx::cvar::CVarType::Float32 => {
+                if let Ok(value) = arg0.to_f32(context) {
+                    if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_double(p_cvar, get_mode_i8, value as f64)} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);                                
+                }                        
+            }
+            advancedfx::cvar::CVarType::Float64 => {
+                if let Ok(value) = arg0.to_number(context) {
+                    if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_double(p_cvar, get_mode_i8, value)} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);                                
+                }                         
+            }
+            advancedfx::cvar::CVarType::String => {
+                if let Ok(value) = arg0.to_string(context) {
+                    let c_string = std::ffi::CString::new(value.to_std_string_escaped()).unwrap();
+                    if !unsafe {advancedfx::cvar::afx_hook_source2_set_convar_string(p_cvar,get_mode_i8, c_string.as_ptr())} {
+                        return Err(Self::set_value_error(context));
+                    }
+                    return Ok(JsValue::Undefined);
+                }                                   
+            }
+            advancedfx::cvar::CVarType::Color => {
+                if let JsValue::Object(value) = arg0 {
+                    if let Ok(array) = JsUint8Array::from_object(value.clone()) {
+                        let vec: Vec<u8> = array.iter(context).collect();
+                        if vec.len() == 4 {
+                            let value = advancedfx::cvar::Color{r:vec[0],g:vec[1],b:vec[2],a:vec[3]};
+                            if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_color(p_cvar, get_mode_i8, &value)} {
                                 return Err(Self::set_value_error(context));
                             }
-                            return Ok(JsValue::Undefined);                                
-                        }
-                        advancedfx::cvar::CVarType::Int16 => {
-                            if let Ok(value) = arg0.to_int16(context) {
-                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int(p_cvar, get_mode_i8, value as i32)} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);                                
-                            }
-                        }
-                        advancedfx::cvar::CVarType::UInt16 => {
-                            if let Ok(value) = arg0.to_uint16(context) {
-                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint(p_cvar, get_mode_i8, value as u32)} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);                                
-                            }
-                        }
-                        advancedfx::cvar::CVarType::Int32 => {
-                            if let Ok(value) = arg0.to_i32(context) {
-                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int(p_cvar, get_mode_i8, value)} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);                                
-                            }
-                        }
-                        advancedfx::cvar::CVarType::UInt32 => {
-                            if let Ok(value) = arg0.to_u32(context) {
-                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint(p_cvar, get_mode_i8, value)} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);                                
-                            }
-                        }
-                        advancedfx::cvar::CVarType::Int64 => {
-                            if let Ok(value) = arg0.to_big_int64(context) {
-                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_int64(p_cvar, get_mode_i8, value)} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);                                
-                            }
-                        }
-                        advancedfx::cvar::CVarType::UInt64 => {
-                            if let Ok(value) = arg0.to_big_uint64(context) {
-                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_uint64(p_cvar, get_mode_i8, value)} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);                                
-                            }                       
-                        }
-                        advancedfx::cvar::CVarType::Float32 => {
-                            if let Ok(value) = arg0.to_f32(context) {
-                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_double(p_cvar, get_mode_i8, value as f64)} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);                                
-                            }                        
-                        }
-                        advancedfx::cvar::CVarType::Float64 => {
-                            if let Ok(value) = arg0.to_number(context) {
-                                if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_double(p_cvar, get_mode_i8, value)} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);                                
-                            }                         
-                        }
-                        advancedfx::cvar::CVarType::String => {
-                            if let Ok(value) = arg0.to_string(context) {
-                                let c_string = std::ffi::CString::new(value.to_std_string_escaped()).unwrap();
-                                if !unsafe {advancedfx::cvar::afx_hook_source2_set_convar_string(p_cvar,get_mode_i8, c_string.as_ptr())} {
-                                    return Err(Self::set_value_error(context));
-                                }
-                                return Ok(JsValue::Undefined);
-                            }                                   
-                        }
-                        advancedfx::cvar::CVarType::Color => {
-                            if let JsValue::Object(value) = arg0 {
-                                if let Ok(array) = JsUint8Array::from_object(value.clone()) {
-                                    let vec: Vec<u8> = array.iter(context).collect();
-                                    if vec.len() == 4 {
-                                        let value = advancedfx::cvar::Color{r:vec[0],g:vec[1],b:vec[2],a:vec[3]};
-                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_color(p_cvar, get_mode_i8, &value)} {
-                                            return Err(Self::set_value_error(context));
-                                        }
-                                        return Ok(JsValue::Undefined);
-                                    }
-                                }
-                            }
-                        }
-                        advancedfx::cvar::CVarType::Vector2 => {
-                            if let JsValue::Object(value) = arg0 {
-                                if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
-                                    let vec: Vec<f32> = array.iter(context).collect();
-                                    if vec.len() == 2 {
-                                        let value = advancedfx::cvar::Vector2{x:vec[0],y:vec[1]};
-                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec2(p_cvar, get_mode_i8, &value)} {
-                                            return Err(Self::set_value_error(context));
-                                        }
-                                        return Ok(JsValue::Undefined);
-                                    }
-                                }                                
-                            }
-                        }
-                        advancedfx::cvar::CVarType::Vector3 => {
-                            if let JsValue::Object(value) = arg0 {
-                                if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
-                                    let vec: Vec<f32> = array.iter(context).collect();
-                                    if vec.len() == 3 {
-                                        let value = advancedfx::cvar::Vector3{x:vec[0],y:vec[1],z:vec[2]};
-                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec3(p_cvar, get_mode_i8, &value)} {
-                                            return Err(Self::set_value_error(context));
-                                        }
-                                        return Ok(JsValue::Undefined);
-                                    }
-                                } 
-                            }
-                        }
-                        advancedfx::cvar::CVarType::Vector4 => {
-                            if let JsValue::Object(value) = arg0 {
-                                if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
-                                    let vec: Vec<f32> = array.iter(context).collect();
-                                    if vec.len() == 4 {
-                                        let value = advancedfx::cvar::Vector4{x:vec[0],y:vec[1],z:vec[2],w:vec[3]};
-                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec4(p_cvar, get_mode_i8, &value)} {
-                                            return Err(Self::set_value_error(context));
-                                        }
-                                        return Ok(JsValue::Undefined);
-                                    }
-                                } 
-                            }
-                        }
-                        advancedfx::cvar::CVarType::Qangle => {
-                            if let JsValue::Object(value) = arg0 {
-                                if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
-                                    let vec: Vec<f32> = array.iter(context).collect();
-                                    if vec.len() == 3 {
-                                        let value = advancedfx::cvar::QAngle{x:vec[0],y:vec[1],z:vec[2]};
-                                        if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_qangle(p_cvar, get_mode_i8, &value)} {
-                                            return Err(Self::set_value_error(context));
-                                        }
-                                        return Ok(JsValue::Undefined);
-                                    }
-                                }    
-                            }
+                            return Ok(JsValue::Undefined);
                         }
                     }
                 }
-                return Err(advancedfx::js::errors::error_arguments(context).into())
+            }
+            advancedfx::cvar::CVarType::Vector2 => {
+                if let JsValue::Object(value) = arg0 {
+                    if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
+                        let vec: Vec<f32> = array.iter(context).collect();
+                        if vec.len() == 2 {
+                            let value = advancedfx::cvar::Vector2{x:vec[0],y:vec[1]};
+                            if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec2(p_cvar, get_mode_i8, &value)} {
+                                return Err(Self::set_value_error(context));
+                            }
+                            return Ok(JsValue::Undefined);
+                        }
+                    }                                
+                }
+            }
+            advancedfx::cvar::CVarType::Vector3 => {
+                if let JsValue::Object(value) = arg0 {
+                    if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
+                        let vec: Vec<f32> = array.iter(context).collect();
+                        if vec.len() == 3 {
+                            let value = advancedfx::cvar::Vector3{x:vec[0],y:vec[1],z:vec[2]};
+                            if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec3(p_cvar, get_mode_i8, &value)} {
+                                return Err(Self::set_value_error(context));
+                            }
+                            return Ok(JsValue::Undefined);
+                        }
+                    } 
+                }
+            }
+            advancedfx::cvar::CVarType::Vector4 => {
+                if let JsValue::Object(value) = arg0 {
+                    if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
+                        let vec: Vec<f32> = array.iter(context).collect();
+                        if vec.len() == 4 {
+                            let value = advancedfx::cvar::Vector4{x:vec[0],y:vec[1],z:vec[2],w:vec[3]};
+                            if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_vec4(p_cvar, get_mode_i8, &value)} {
+                                return Err(Self::set_value_error(context));
+                            }
+                            return Ok(JsValue::Undefined);
+                        }
+                    } 
+                }
+            }
+            advancedfx::cvar::CVarType::Qangle => {
+                if let JsValue::Object(value) = arg0 {
+                    if let Ok(array) = JsFloat32Array::from_object(value.clone()) {
+                        let vec: Vec<f32> = array.iter(context).collect();
+                        if vec.len() == 3 {
+                            let value = advancedfx::cvar::QAngle{x:vec[0],y:vec[1],z:vec[2]};
+                            if !unsafe{advancedfx::cvar::afx_hook_source2_set_convar_qangle(p_cvar, get_mode_i8, &value)} {
+                                return Err(Self::set_value_error(context));
+                            }
+                            return Ok(JsValue::Undefined);
+                        }
+                    }    
+                }
             }
         }
-        Self::error_typ(context)        
+
+        Ok(JsValue::Undefined)
     }
 
     fn get_value(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
@@ -368,45 +367,42 @@ impl CVar {
     }   
 
     fn get_type(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        if let Some(object) = this.as_object() {
-            if let Some(object_inner) = object.downcast_ref::<CVar>() {
-                let p_cvar = object_inner.native;
-                let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
-                return Ok(JsValue::Integer(cvar_type as i32))
-            }
-        }
-        Self::error_typ(context)
+        let object = this.as_object().ok_or(Self::error_typ(context).unwrap_err())?;
+        let object_inner = object.downcast_ref::<CVar>().ok_or(Self::error_typ(context).unwrap_err())?;
+
+        let p_cvar = object_inner.native;
+        let cvar_type = advancedfx::cvar::afx_get_convar_type(p_cvar);
+
+        Ok(JsValue::Integer(cvar_type as i32))
     }
 
     fn get_name(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        if let Some(object) = this.as_object() {
-            if let Some(object_inner) = object.downcast_ref::<CVar>() {
-                let p_cvar = object_inner.native;
-                let mut result: *const c_char = std::ptr::null();
-                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_name(p_cvar,&mut result)} {
-                    if !result.is_null() {
-                        return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
-                    }
-                }
-                return Ok(JsValue::Undefined); // This probably will never happen, just here in case.
+        let object = this.as_object().ok_or(Self::error_typ(context).unwrap_err())?;
+        let object_inner = object.downcast_ref::<CVar>().ok_or(Self::error_typ(context).unwrap_err())?;
+
+        let p_cvar = object_inner.native;
+        let mut result: *const c_char = std::ptr::null();
+        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_name(p_cvar,&mut result)} {
+            if !result.is_null() {
+                return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
             }
         }
-        Self::error_typ(context)
+
+        Ok(JsValue::Undefined) // This probably will never happen, just here in case.
     }
     fn get_help_string(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        if let Some(object) = this.as_object() {
-            if let Some(object_inner) = object.downcast_ref::<CVar>() {
-                let p_cvar = object_inner.native;
-                let mut result: *const c_char = std::ptr::null();
-                if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_help_string(p_cvar,&mut result)} {
-                    if !result.is_null() {
-                        return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
-                    }
-                }
-                return Ok(JsValue::Undefined);
+        let object = this.as_object().ok_or(Self::error_typ(context).unwrap_err())?;
+        let object_inner = object.downcast_ref::<CVar>().ok_or(Self::error_typ(context).unwrap_err())?;
+
+        let p_cvar = object_inner.native;
+        let mut result: *const c_char = std::ptr::null();
+        if unsafe {advancedfx::cvar::afx_hook_source2_get_convar_help_string(p_cvar,&mut result)} {
+            if !result.is_null() {
+                return Ok(JsValue::String(js_string!(unsafe { CStr::from_ptr(result) }.to_str().unwrap().to_string())));
             }
         }
-        Self::error_typ(context)
+
+        Ok(JsValue::Undefined)
     }
 }
 
@@ -419,16 +415,16 @@ impl Class for CVar {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<Self> {
-        if 1 == args.len() {
-            if let Ok(index) = args[0].to_i32(context) {
-                let cvar = unsafe { advancedfx::cvar::afx_hook_source2_get_convar(index as usize) };
-                if cvar.is_null() {
-                    return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"not a valid cvar", context).into());
-                }
-                return Ok(CVar::new(cvar));
-            }
+        if 1 != args.len() { return Err(advancedfx::js::errors::error_arguments(context).into()) };
+
+        let index = args[0].to_i32(context).or_else(|_| Err(advancedfx::js::errors::error_arguments(context)))?;
+
+        let cvar = unsafe { advancedfx::cvar::afx_hook_source2_get_convar(index as usize) };
+        if cvar.is_null() {
+            return Err(advancedfx::js::errors::make_error!(JsNativeError::error(),"not a valid cvar", context).into());
         }
-        Err(advancedfx::js::errors::error_arguments(context).into())
+
+        Ok(CVar::new(cvar))
     }
 
     fn init(class: &mut ClassBuilder<'_>) -> JsResult<()> {

--- a/AfxHookSource2Rs/src/advancedfx/js/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/js/mod.rs
@@ -1,4 +1,5 @@
 pub mod campath;
+pub mod cvar;
 pub mod errors;
 pub mod math;
 

--- a/AfxHookSource2Rs/src/advancedfx/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/mod.rs
@@ -1,3 +1,4 @@
 pub mod math;
 pub mod campath;
+pub mod cvar;
 pub mod js;

--- a/AfxHookSource2Rs/src/lib.rs
+++ b/AfxHookSource2Rs/src/lib.rs
@@ -2439,6 +2439,8 @@ impl AfxHookSource2Rs {
         advancedfx::js::campath::Iterator::add_to_context(&mut context);
         advancedfx::js::campath::Campath::add_to_context(&mut context);
 
+        advancedfx::js::cvar::CVar::add_to_context(&mut context);
+
         ConCommandsArgs::add_to_context(&mut context);
         ConCommandBox::add_to_context(&mut context);
 

--- a/misc/mirv-script/src/snippets/CMakeLists.txt
+++ b/misc/mirv-script/src/snippets/CMakeLists.txt
@@ -9,6 +9,7 @@ set(AFXHOOKSOURCE2SNIPPETS_NAMES
     mirv_script_voice
     observer-test
     attachment-test
+	cvars-test
     quit-when-demo-is-paused
 )
 

--- a/misc/mirv-script/src/snippets/cvars-test.ts
+++ b/misc/mirv-script/src/snippets/cvars-test.ts
@@ -1,0 +1,98 @@
+{
+	const typesMap = {
+		[-1]: 'Invalid',
+		0: 'Bool',
+		1: 'Int16',
+		2: 'UInt16',
+		3: 'Int32',
+		4: 'UInt32',
+		5: 'Int64',
+		6: 'UInt64',
+		7: 'Float32',
+		8: 'Float64',
+		9: 'String',
+		10: 'Color',
+		11: 'Vector2',
+		12: 'Vector3',
+		13: 'Vector4',
+		14: 'Qangle'
+	} as const;
+
+	function getCvarByName(name: string) {
+		const idx = AdvancedfxCVar.getIndexFromName(name);
+		if (!idx) return;
+
+		let cvar: AdvancedfxCVar | null = null;
+		try {
+			cvar = new AdvancedfxCVar(idx);
+		} catch {
+			return;
+		}
+
+		return cvar;
+	}
+
+	function printCvar(name: string) {
+		const cvar = getCvarByName(name);
+		if (!cvar) return;
+
+		const msg = [name];
+		msg.push(`\ttype: ${cvar.getType()} / ${typesMap[cvar.getType()]}`);
+		msg.push(`\tvalue: ${cvar.value}`);
+		msg.push(`\thelp: ${cvar.helpString}`);
+		msg.push(`\tdefault value: ${cvar.defaultValue}`);
+		msg.push(`\tmin value: ${cvar.minValue}`);
+		msg.push(`\tmax value: ${cvar.maxValue}`);
+
+		console.log(msg.join('\n'));
+	}
+
+	const typesFound: AdvancedfxCVar.TypeEnum[] = [];
+
+	for (let i = 0; i < 8192; i++) {
+		let cvar = null;
+
+		try {
+			cvar = new AdvancedfxCVar(i);
+		} catch {
+			console.log(`Last valid cvar index ${i - 1}`);
+		}
+
+		if (cvar === null) break;
+
+		const type = cvar.getType();
+		if (undefined === typesFound.find((v) => v === type)) typesFound.push(type);
+	}
+
+	console.log('Types found:');
+	typesFound.sort((a, b) => a - b);
+	for (const t of typesFound) {
+		console.log(`${t}: ${typesMap[t]}`);
+	}
+
+	// We cannot access hidden ones by name
+	mirv.exec('mirv_cvar_unhide_all');
+
+	// Game doesn't use all types for cvars
+	printCvar('bot_allow_grenades'); // Bool
+	printCvar('bot_debug'); // Int32
+	printCvar('snd_steamaudio_active_hrtf'); // UInt32
+	printCvar('tv_allow_camera_man_steamid'); // UInt64
+	printCvar('cl_crosshairgap'); // Float32
+	printCvar('cl_language'); // String
+	printCvar('cl_teammate_color_1'); // Color
+	printCvar('lb_override_barn_light_fade_sizes'); // Vector2
+	printCvar('cl_eye_target_override'); // Vector3
+
+	const fps_max = getCvarByName('fps_max');
+	if (fps_max) {
+		const oldValue = fps_max.value;
+		console.log('Current fps_max:', fps_max.value);
+		console.log('Setting it to', 400);
+		fps_max.value = 400;
+		console.log('Current fps_max:', fps_max.value);
+		console.log('Restoring previous fps_max value');
+		fps_max.value = oldValue;
+		console.log('Current fps_max:', fps_max.value);
+	}
+}

--- a/misc/mirv-script/src/types/cvar.d.ts
+++ b/misc/mirv-script/src/types/cvar.d.ts
@@ -28,14 +28,13 @@ declare namespace AdvancedfxCVar {
      * Type mappings (JS - AdvancedfxCVar.TypeEnum):
      * boolean - Bool,
      * number - Int16, UInt16, Int32, UInt32, Float32, Float64
-     * BigInt - Int64, Int64
+     * bigint - Int64, UInt64
      * string - String
-     * Color - Color
-     * Vector2 - Vector2
-     * Vector3 - Vector3, Qangle
-     * Vector4 - Vector4
+     * Vector2 - Vector2(x,y)
+     * Vector3 - Vector3(x,y,z), Qangle(x,y,z)
+     * Vector4 - Vector4(x,y,z,w), Color(r,g,b,a)
      */
-    type Type = boolean | number | bigint | string | Color | Vector2 | Vector3 | Vector4;
+    type Type = boolean | number | bigint | string | Vector2 | Vector3 | Vector4;
 }
 
 declare class AdvancedfxCVar {

--- a/misc/mirv-script/src/types/cvar.d.ts
+++ b/misc/mirv-script/src/types/cvar.d.ts
@@ -47,7 +47,8 @@ declare class AdvancedfxCVar {
     static isValidIndex(index: number): boolean;
 
     /**
-     * Find a cvar by name
+     * Find a cvar by name.
+     * @remarks Hidden cvars can NOT be accessed this way.
      * @throws Error
      * If cvar can not be found (yet).
      */
@@ -55,7 +56,8 @@ declare class AdvancedfxCVar {
 
     /**
      * Find a cvar by index
-     * @remarks Use AdvancedfxCVar.isValidIndex to determine if an index is valid in advance.
+     * @remarks Hidden cvars CAN be accessed this way.
+     * Use AdvancedfxCVar.isValidIndex to determine if an index is valid in advance.
      * @throws Error
      * If cvar can not be found (yet).
      */
@@ -63,11 +65,15 @@ declare class AdvancedfxCVar {
 
     getType(): AdvancedfxCVar.TypeEnum;
 
+    readonly name: string;
+
+    readonly helpString: string | undefined;
+
     /**
-     * get CVar value
+     * get / set CVar value
      * @remarks for type mappings see AdvancedfxCVar.Type.
      */
-    readonly value: AdvancedfxCVar.Type;
+    value: AdvancedfxCVar.Type;
 
     /**
      * get CVar default value

--- a/misc/mirv-script/src/types/cvar.d.ts
+++ b/misc/mirv-script/src/types/cvar.d.ts
@@ -1,0 +1,89 @@
+declare namespace AdvancedfxCVar {
+    enum TypeEnum {
+        Invalid = -1,
+        Bool = 0,
+        Int16 = 1,
+        UInt16 = 2,
+        Int32 = 3,
+        UInt32 = 4,
+        Int64 = 5,
+        UInt64 = 6,
+        Float32 = 7,
+        Float64 = 8,
+        String = 9,
+        Color = 10,
+        Vector2 = 11,
+        Vector3 = 12,
+        Vector4 = 13,
+        Qangle = 14
+    }
+
+    type Vector2 = number[2];
+
+    type Vector3 = number[3];
+
+    type Vector4 = number[4];
+
+    /**
+     * Type mappings (JS - AdvancedfxCVar.TypeEnum):
+     * boolean - Bool,
+     * number - Int16, UInt16, Int32, UInt32, Float32, Float64
+     * BigInt - Int64, Int64
+     * string - String
+     * Color - Color
+     * Vector2 - Vector2
+     * Vector3 - Vector3, Qangle
+     * Vector4 - Vector4
+     */
+    type Type = boolean | number | bigint | string | Color | Vector2 | Vector3 | Vector4;
+}
+
+declare class AdvancedfxCVar {
+
+    /**
+     * Determine if there's is a cvar yet with this index.
+     * @param index the index of the cvar, typical values are in [0,65535].
+     */
+    static isValidIndex(index: number): boolean;
+
+    /**
+     * Find a cvar by name
+     * @throws Error
+     * If cvar can not be found (yet).
+     */
+    constructor(name: string);
+
+    /**
+     * Find a cvar by index
+     * @remarks Use AdvancedfxCVar.isValidIndex to determine if an index is valid in advance.
+     * @throws Error
+     * If cvar can not be found (yet).
+     */
+    constructor(index: number);
+
+    getType(): AdvancedfxCVar.TypeEnum;
+
+    /**
+     * get CVar value
+     * @remarks for type mappings see AdvancedfxCVar.Type.
+     */
+    readonly value: AdvancedfxCVar.Type;
+
+    /**
+     * get CVar default value
+     * @remarks for type mappings see AdvancedfxCVar.Type.
+     */
+    readonly defaultValue: AdvancedfxCVar.Type;
+
+    /**
+      * get CVar minimum value (if any is set).
+      * @remarks for type mappings see AdvancedfxCVar.Type.
+      */
+    readonly minValue: AdvancedfxCVar.Type | undefined;
+
+    /**
+      * get CVar maximum value (if any is set).
+      * @remarks for type mappings see AdvancedfxCVar.Type.
+      */
+    readonly maxValue: AdvancedfxCVar.Type | undefined;
+}

--- a/misc/mirv-script/src/types/cvar.d.ts
+++ b/misc/mirv-script/src/types/cvar.d.ts
@@ -1,86 +1,85 @@
 declare namespace AdvancedfxCVar {
-    enum TypeEnum {
-        Invalid = -1,
-        Bool = 0,
-        Int16 = 1,
-        UInt16 = 2,
-        Int32 = 3,
-        UInt32 = 4,
-        Int64 = 5,
-        UInt64 = 6,
-        Float32 = 7,
-        Float64 = 8,
-        String = 9,
-        Color = 10,
-        Vector2 = 11,
-        Vector3 = 12,
-        Vector4 = 13,
-        Qangle = 14
-    }
+	enum TypeEnum {
+		Invalid = -1,
+		Bool = 0,
+		Int16 = 1,
+		UInt16 = 2,
+		Int32 = 3,
+		UInt32 = 4,
+		Int64 = 5,
+		UInt64 = 6,
+		Float32 = 7,
+		Float64 = 8,
+		String = 9,
+		Color = 10,
+		Vector2 = 11,
+		Vector3 = 12,
+		Vector4 = 13,
+		Qangle = 14
+	}
 
-    type Vector2 = number[2];
+	type Vector2 = number[2];
 
-    type Vector3 = number[3];
+	type Vector3 = number[3];
 
-    type Vector4 = number[4];
+	type Vector4 = number[4];
 
-    /**
-     * Type mappings (JS - AdvancedfxCVar.TypeEnum):
-     * boolean - Bool,
-     * number - Int16, UInt16, Int32, UInt32, Float32, Float64
-     * bigint - Int64, UInt64
-     * string - String
-     * Vector2 - Vector2(x,y)
-     * Vector3 - Vector3(x,y,z), Qangle(x,y,z)
-     * Vector4 - Vector4(x,y,z,w), Color(r,g,b,a)
-     */
-    type Type = boolean | number | bigint | string | Vector2 | Vector3 | Vector4;
+	/**
+	 * Type mappings (JS - AdvancedfxCVar.TypeEnum):
+	 * boolean - Bool,
+	 * number - Int16, UInt16, Int32, UInt32, Float32, Float64
+	 * bigint - Int64, UInt64
+	 * string - String
+	 * Vector2 - Vector2(x,y)
+	 * Vector3 - Vector3(x,y,z), Qangle(x,y,z)
+	 * Vector4 - Vector4(x,y,z,w), Color(r,g,b,a)
+	 */
+	type Type = boolean | number | bigint | string | Vector2 | Vector3 | Vector4;
 }
 
 declare class AdvancedfxCVar {
+	/**
+	 * Find a non-hidden cvar by name.
+	 * @remarks Hidden cvars can NOT be accessed this way.
+	 */
+	static getIndexFromName(name: string): number | undefined;
 
-    /**
-     * Find a non-hidden cvar by name.
-     * @remarks Hidden cvars can NOT be accessed this way.
-    */
-    static getIndexFromName(name: string): number | undefined;
+	/**
+	 * Find a cvar by index
+	 * @remarks Hidden cvars CAN be accessed this way.
+	 * @param index Hint: currently sane possible values are in [0,8191].
+	 * @throws Error
+	 * If cvar can not be found for this index (yet).
+	 */
+	constructor(index: number);
 
-    /**
-     * Find a cvar by index
-     * @remarks Hidden cvars CAN be accessed this way.
-     * @param index Hint: currently sane possible values are in [0,8191].
-     * @throws Error
-     * If cvar can not be found for this index (yet).
-     */
-    constructor(index: number);
+	getType(): AdvancedfxCVar.TypeEnum;
 
-    getType(): AdvancedfxCVar.TypeEnum;
+	readonly name: string;
 
-    readonly name: string;
+	readonly helpString: string | undefined;
 
-    readonly helpString: string | undefined;
+	/**
+	 * get / set CVar value
+	 * @remarks for type mappings see AdvancedfxCVar.Type.
+	 */
+	value: AdvancedfxCVar.Type;
 
-    /**
-     * get / set CVar value
-     * @remarks for type mappings see AdvancedfxCVar.Type.
-     */
-    value: AdvancedfxCVar.Type;
+	/**
+	 * get CVar default value
+	 * @remarks for type mappings see AdvancedfxCVar.Type.
+	 */
+	readonly defaultValue: AdvancedfxCVar.Type;
 
-    /**
-     * get CVar default value
-     * @remarks for type mappings see AdvancedfxCVar.Type.
-     */
-    readonly defaultValue: AdvancedfxCVar.Type;
+	/**
+	 * get CVar minimum value (if any is set).
+	 * @remarks for type mappings see AdvancedfxCVar.Type.
+	 */
+	readonly minValue: AdvancedfxCVar.Type | undefined;
 
-    /**
-      * get CVar minimum value (if any is set).
-      * @remarks for type mappings see AdvancedfxCVar.Type.
-      */
-    readonly minValue: AdvancedfxCVar.Type | undefined;
-
-    /**
-      * get CVar maximum value (if any is set).
-      * @remarks for type mappings see AdvancedfxCVar.Type.
-      */
-    readonly maxValue: AdvancedfxCVar.Type | undefined;
+	/**
+	 * get CVar maximum value (if any is set).
+	 * @remarks for type mappings see AdvancedfxCVar.Type.
+	 */
+	readonly maxValue: AdvancedfxCVar.Type | undefined;
 }

--- a/misc/mirv-script/src/types/cvar.d.ts
+++ b/misc/mirv-script/src/types/cvar.d.ts
@@ -41,25 +41,17 @@ declare namespace AdvancedfxCVar {
 declare class AdvancedfxCVar {
 
     /**
-     * Determine if there's is a cvar yet with this index.
-     * @param index the index of the cvar, typical values are in [0,65535].
-     */
-    static isValidIndex(index: number): boolean;
-
-    /**
-     * Find a cvar by name.
+     * Find a non-hidden cvar by name.
      * @remarks Hidden cvars can NOT be accessed this way.
-     * @throws Error
-     * If cvar can not be found (yet).
-     */
-    constructor(name: string);
+    */
+    static getIndexFromName(name: string): number | undefined;
 
     /**
      * Find a cvar by index
      * @remarks Hidden cvars CAN be accessed this way.
-     * Use AdvancedfxCVar.isValidIndex to determine if an index is valid in advance.
+     * @param index Hint: currently sane possible values are in [0,8191].
      * @throws Error
-     * If cvar can not be found (yet).
+     * If cvar can not be found for this index (yet).
      */
     constructor(index: number);
 


### PR DESCRIPTION
(Planning to make them setable before release still.)

This is an yet untested draft, so it can be reviewed what I am working on, if it makes any sense.

Edit:
- Implements cvar stuff for https://github.com/advancedfx/advancedfx/issues/1047

Edit2:

Two (not necessarily showing all possible features\*) example scripts:

```
{
	// Example script to get all cvars, including hidden ones.
	// Please note that some cvars are only registered late / in-game, so running it again later may reveal new cvars with higher indices
	for(var i=0;i<8192;i++) {
		var cvar;
		try {
			cvar = new AdvancedfxCVar(i);
		}
		catch{
			cvar = null;
		}
		if(cvar === null) break;
		console.log(i,cvar.name,cvar.value,cvar.helpString);
	}
}
```
```
{
	// Example script to get a specific cvar (not including hidden ones):
	var index = AdvancedfxCVar.getIndexFromName("fps_max");
	if(undefined !== index) {
		var cvar = new AdvancedfxCVar(index);
		console.log(cvar.name,cvar.value,cvar.helpString);
		cvar.value = 120;
	} else {
		console.log("fps_max is not available / registered yet or hidden");
	}
}
```
\* missing e.g.: defaultValue, minValue, maxValue, getType()