### PR TITLE
GoldSrc: Add FFMPEG support for mirv_depth_exr 1

### DIFF
--- a/AfxHookGoldSrc/filming.cpp
+++ b/AfxHookGoldSrc/filming.cpp
@@ -2223,7 +2223,7 @@ void FilmingStream::PrintExr(float const* data)
 
 	if (!m_FfmpegOptions.empty())
 	{
-		advancedfx::ImageFormat format = advancedfx::ImageFormat::ZFLoat;
+		advancedfx::ImageFormat format = advancedfx::ImageFormat::ZFloat;
 
 		advancedfx::CImageFormat imageFormat(
 			format, m_Width, m_Height, m_Pitch);
@@ -2236,7 +2236,7 @@ void FilmingStream::PrintExr(float const* data)
 		
 		advancedfx::CImageBuffer buffer;
 		buffer.Format = imageFormat;
-		buffer.Buffer = const_cast<unsigned char *>(data); //TODO: not nice this cast.
+		buffer.Buffer = const_cast<float *>(data); //TODO: not nice this cast.
 
 		if (!m_FfmpegOutStream->SupplyVideoData(buffer))
 		{

--- a/AfxHookGoldSrc/filming.cpp
+++ b/AfxHookGoldSrc/filming.cpp
@@ -2221,19 +2221,47 @@ void FilmingStream::PrintExr(float const* data)
 	if (!m_DirCreated)
 		return;
 
-	std::wostringstream os;
-	os << m_Path << L"\\" << setfill(L'0') << setw(5) << m_FrameCount << setw(0) << L".exr";
+	if (!m_FfmpegOptions.empty())
+	{
+		advancedfx::ImageFormat format = advancedfx::ImageFormat::ZFLoat;
 
-	WriteFloatZOpenExr(
-		os.str().c_str(),
-		(unsigned char*)data,
-		m_Width,
-		m_Height,
-		sizeof(float),
-		m_Pitch,
-		2 == depth_exr->value ? WFZOEC_Zip : WFZOEC_None,
-		false
-	);
+		advancedfx::CImageFormat imageFormat(
+			format, m_Width, m_Height, m_Pitch);
+
+		if (nullptr == m_FfmpegOutStream)
+		{
+			m_FfmpegOutStream = new advancedfx::COutFFMPEGVideoStream(imageFormat, m_Path, m_FfmpegOptions, movie_fps->value);
+			m_FfmpegOutStream->AddRef();
+		}
+		
+		advancedfx::CImageBuffer buffer;
+		buffer.Format = imageFormat;
+		buffer.Buffer = const_cast<unsigned char *>(data); //TODO: not nice this cast.
+
+		if (!m_FfmpegOutStream->SupplyVideoData(buffer))
+		{
+			std::string path("n/a");
+			WideStringToUTF8String(m_Path.c_str(), path);
+			pEngfuncs->Con_Printf("AFXERROR: Failed writing image to stream for \"%s\".\n", path.c_str());
+		}
+
+		buffer.Buffer = nullptr;
+	}	
+	else {		
+		std::wostringstream os;
+		os << m_Path << L"\\" << setfill(L'0') << setw(5) << m_FrameCount << setw(0) << L".exr";
+
+		WriteFloatZOpenExr(
+			os.str().c_str(),
+			(unsigned char*)data,
+			m_Width,
+			m_Height,
+			sizeof(float),
+			m_Pitch,
+			2 == depth_exr->value ? WFZOEC_Zip : WFZOEC_None,
+			false
+		);
+	}
 
 	m_FrameCount++;
 }


### PR DESCRIPTION
Example:

```
mirv_movie_depthdump 1
mirv_depth_exr 1
mirv_movie_ffmpeg depthMain enabled 1
mirv_movie_ffmpeg depthMain options "-c:v libx264 -pix_fmt gray -preset slow -crf 22 {QUOTE}{AFX_STREAM_PATH}\\video.mp4{QUOTE}"
// uncomment for 10 instead of 8 bit: //mirv_movie_ffmpeg depthMain options "-c:v libx264 -pix_fmt gray10le -preset slow -crf 22 {QUOTE}{AFX_STREAM_PATH}\\video.mp4{QUOTE}"
// (not sure which codecs support >=24 bit per channel)
// ...
```