### PR TITLE
TF2 Classified support with mirv_agr error fix

### DIFF
--- a/AfxHookSource/MaterialSystemHooks.cpp
+++ b/AfxHookSource/MaterialSystemHooks.cpp
@@ -118,6 +118,7 @@ bool MaterialSystem_ExecuteOnRenderThread(CMaterialSystemFunctor * pFunctor) {
                 case SourceSdkVer_CSS:
                 case SourceSdkVer_L4D2:
                 case SourceSdkVer_TF2:
+                case SourceSdkVer_TF2Classified:
                 case SourceSdkVer_HL2MP:
                     pFunctor2->AddRef();
                     break;
@@ -128,6 +129,7 @@ bool MaterialSystem_ExecuteOnRenderThread(CMaterialSystemFunctor * pFunctor) {
 #ifndef _WIN64
                     case SourceSdkVer_CSS:
                     case SourceSdkVer_TF2:
+                    case SourceSdkVer_TF2Classified:
                     case SourceSdkVer_HL2MP:
                         this_offset = 0xa4;
                         break;

--- a/AfxHookSource/addresses.cpp
+++ b/AfxHookSource/addresses.cpp
@@ -698,7 +698,7 @@ void Addresses_InitEngineDll(AfxAddr engineDll, SourceSdkVer sourceSdkVer)
 #ifndef _WIN64		
 		SourceSdkVer_CSGO == sourceSdkVer || SourceSdkVer_CSCO == sourceSdkVer ||
 #endif
-		SourceSdkVer_TF2 == sourceSdkVer
+		SourceSdkVer_TF2 == sourceSdkVer || SourceSdkVer_TF2Classified == sourceSdkVer
 	)
 	{
 		// csgo_engine_Cmd_ExecuteCommand: // Checked 2019-11-11.
@@ -847,6 +847,7 @@ void Addresses_InitEngineDll(AfxAddr engineDll, SourceSdkVer sourceSdkVer)
 			void **vtable = (void **)FindClassVtable((HMODULE)engineDll, ".?AVCVideoMode_Common@@", 0, 0x0);
 			if(vtable) AFXADDR_SET(engine_CVideoMode_Common_WriteMovieFrame, (size_t)(vtable[23]));
 		} break;
+		case SourceSdkVer_TF2Classified:
 		case SourceSdkVer_TF2: {
 			// Checked x86: 2024-01-05.
 			void **vtable = (void **)FindClassVtable((HMODULE)engineDll, ".?AVCVideoMode_MaterialSystem@@", 0, 0x0);
@@ -891,6 +892,7 @@ void Addresses_InitEngineDll(AfxAddr engineDll, SourceSdkVer sourceSdkVer)
 		switch(sourceSdkVer) {
 			//case SourceSdkVer_CSSV84:
 			case SourceSdkVer_CSS:
+			case SourceSdkVer_TF2Classified:
 			case SourceSdkVer_TF2: { // Checked 2024-03-22
 				ImageSectionsReader sections((HMODULE)engineDll);
 				if (!sections.Eof())
@@ -2920,7 +2922,15 @@ void Addresses_InitClientDll(AfxAddr clientDll, SourceSdkVer sourceSdkVer)
 									else ErrorBox(MkErrStr(__FILE__, __LINE__));	
 								}
 								break;
-							}	
+							case SourceSdkVer_TF2Classified:
+								{
+									MemRange result = FindPatternString(textRange.And(MemRange(refStrAddr - 0x84, refStrAddr -0x84 + 6)), "56 41 54 41 57 48");
+									if(!result.IsEmpty())
+										AFXADDR_SET(tf2_client_C_BaseAnimating_RecordBones, result.Start);
+									else ErrorBox(MkErrStr(__FILE__, __LINE__));	
+								}
+								break;
+							}
 						}					
 						else ErrorBox(MkErrStr(__FILE__, __LINE__));	
 					}
@@ -3195,6 +3205,7 @@ void Addresses_InitMaterialsystemDll(AfxAddr materialsystemDll, SourceSdkVer sou
 			AFXADDR_SET(materialsystem_CFunctor_vtable_size, 4);
 			break;
 #endif //#ifndef _WIN64			
+		case SourceSdkVer_TF2Classified:
 		case SourceSdkVer_TF2:
 			// Checked 2024-04-22.
 			materialsystem_GetRenderCallQueue_vtable_offset = 148;
@@ -3260,6 +3271,7 @@ void Addresses_InitMaterialsystemDll(AfxAddr materialsystemDll, SourceSdkVer sou
 #ifndef _WIN64
 					case SourceSdkVer_CSS:
 					case SourceSdkVer_TF2:
+					case SourceSdkVer_TF2Classified:
 					case SourceSdkVer_HL2MP:
 						AFXADDR_SET(materialsystem_CMatCallQueue_QueueFunctor, tmpAddr); // If this chnanges, then this offset in MaterialSystemHooks.cpp for pQueueFunctorInternal needs to be changed!
 						break;

--- a/AfxHookSource/addresses.h
+++ b/AfxHookSource/addresses.h
@@ -8,6 +8,7 @@ enum SourceSdkVer
 	SourceSdkVer_CSGO,
 	SourceSdkVer_CSCO,
 	SourceSdkVer_TF2,
+	SourceSdkVer_TF2Classified,
 	SourceSdkVer_CSS,
 	SourceSdkVer_CSSV34,
 	SourceSdkVer_CSSV84,

--- a/AfxHookSource/csgo/hooks/engine/cmd.cpp
+++ b/AfxHookSource/csgo/hooks/engine/cmd.cpp
@@ -141,7 +141,7 @@ bool Install_csgo_tf2_Cmd_ExecuteCommand(void)
 		error = DetourTransactionCommit();
 
 		firstResult = NO_ERROR == error;
-	} else if(SourceSdkVer_TF2 == g_SourceSdkVer && AFXADDR_GET(tf2_engine_Cmd_ExecuteCommand)){
+	} else if((SourceSdkVer_TF2 == g_SourceSdkVer || SourceSdkVer_TF2Classified == g_SourceSdkVer) && AFXADDR_GET(tf2_engine_Cmd_ExecuteCommand)){
 		LONG error = NO_ERROR;
 
 		g_tf2_engine_Cmd_ExecuteCommand = (tf2_engine_Cmd_ExecuteCommand_t)AFXADDR_GET(tf2_engine_Cmd_ExecuteCommand);

--- a/AfxHookSource/main.cpp
+++ b/AfxHookSource/main.cpp
@@ -198,6 +198,7 @@ FovScaling GetDefaultFovScaling() {
 	case SourceSdkVer_CSGO:
 	case SourceSdkVer_CSCO:
 	case SourceSdkVer_TF2:
+	case SourceSdkVer_TF2Classified:
 	case SourceSdkVer_SWARM:
 	case SourceSdkVer_L4D2:
 	case SourceSdkVer_Momentum:
@@ -2193,6 +2194,7 @@ void* new_Client_CreateInterface(const char *pName, int *pReturnCode)
 					AfxDetourPtr((PVOID*)&(vtable[2]), new_CVClient_Shutdown, (PVOID*)&old_CVClient_Shutdown);
 					AfxDetourPtr((PVOID*)&(vtable[35]), new_CVClient_FrameStageNotify_Garrysmod, (PVOID*)&old_CVClient_FrameStageNotify_Garrysmod);
 					break;
+				case SourceSdkVer_TF2Classified:
 				case SourceSdkVer_TF2:
 					AfxDetourPtr((PVOID*) & (vtable[2]), new_CVClient_Shutdown, (PVOID*)&old_CVClient_Shutdown);
 					AfxDetourPtr((PVOID*) & (vtable[35]), new_CVClient_FrameStageNotify_TF2, (PVOID*)&old_CVClient_FrameStageNotify_TF2);
@@ -2236,7 +2238,7 @@ void* new_Client_CreateInterface(const char *pName, int *pReturnCode)
 				new CClientToolsCsgo(iface);
 		}
 #endif //#ifndef _WIN64		
-		if (SourceSdkVer_TF2 == g_SourceSdkVer) {
+		if (SourceSdkVer_TF2 == g_SourceSdkVer || SourceSdkVer_TF2Classified == g_SourceSdkVer) {
 
 			if (SOURCESDK::TF2::IClientTools * iface = (SOURCESDK::TF2::IClientTools *)old_Client_CreateInterface(SOURCESDK_TF2_VCLIENTTOOLS_INTERFACE_VERSION, NULL))
 				new CClientToolsTf2(iface);
@@ -2660,6 +2662,8 @@ void CommonHooks()
 				const wchar_t* game = g_CommandLine->GetArgV(gameIdx);
 				if (0 == _wcsicmp(L"tf", game))
 					g_SourceSdkVer = SourceSdkVer_TF2;
+				else if (0 == _wcsicmp(L"tf2classified", game))
+					g_SourceSdkVer = SourceSdkVer_TF2Classified;
 				else if (0 == _wcsicmp(L"csgo", game))
 					g_SourceSdkVer = SourceSdkVer_CSGO;
 				else if (0 == _wcsicmp(L"csco", game))
@@ -2728,6 +2732,10 @@ void CommonHooks()
 		{
 			g_SourceSdkVer = SourceSdkVer_TF2;
 		}
+		else if (StringIEndsWith(filePath, "tf2classified_win64.exe"))
+		{
+			g_SourceSdkVer = SourceSdkVer_TF2Classified;
+		}
 		else if (StringIEndsWith(filePath, "hl2mp.exe"))
 		{
 			g_SourceSdkVer = SourceSdkVer_HL2MP;
@@ -2744,6 +2752,8 @@ void CommonHooks()
 				const wchar_t* game = g_CommandLine->GetArgV(gameIdx);
 				if(0 == _wcsicmp(L"tf", game))
 					g_SourceSdkVer = SourceSdkVer_TF2;
+				else if (0 == _wcsicmp(L"tf2classified", game))
+					g_SourceSdkVer = SourceSdkVer_TF2Classified;
 				else if (0 == _wcsicmp(L"cstrike", game))
 					g_SourceSdkVer = SourceSdkVer_CSS;
 				else if (0 == _wcsicmp(L"garrysmod", game))


### PR DESCRIPTION
includes 
- new game parameter -afxGame tf2classified
- new game detection for Team Fortress 2 Classified
- updated pattern and offset for tf2_client_C_BaseAnimating_RecordBones