### PR TITLE
Add client-side VScript interface.

### DIFF
--- a/AfxHookSource2/AfxHookSource2Rs.cpp
+++ b/AfxHookSource2/AfxHookSource2Rs.cpp
@@ -14,6 +14,7 @@
 
 #include "WrpConsole.h"
 #include "hlaeFolder.h"
+#include "VScript.h"
 
 #include <string>
 #include <filesystem>
@@ -31,6 +32,11 @@ extern "C" void afx_hook_source2_warning(const char * pszValue) {
 extern "C" void afx_hook_source2_exec(const char * pszValue) {
     if(g_pEngineToClient) g_pEngineToClient->ExecuteClientCmd(0,pszValue,true);
 }
+
+extern "C" bool afx_hook_source2_vscript_exec_client(const char * pszValue) {
+    return BOOL_TO_FFIBOOL(ExecuteClientVScript(pszValue));
+}
+
 
 bool g_b_on_record_start = false;
 

--- a/AfxHookSource2/CMakeLists.txt
+++ b/AfxHookSource2/CMakeLists.txt
@@ -223,6 +223,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ClientEntitySystem.h
 
     ConsoleRs.cpp
+
     CVarRs.cpp
 
 	DeathMsg.cpp
@@ -276,6 +277,9 @@ target_sources(${PROJECT_NAME} PRIVATE
 	SceneSystem.h
 
     StreamSettings.h
+
+    VScript.cpp
+    VScript.h
 
     WrpConsole.cpp
     WrpConsole.h

--- a/AfxHookSource2/ClientEntitySystem.cpp
+++ b/AfxHookSource2/ClientEntitySystem.cpp
@@ -15,7 +15,6 @@
 #include "AfxHookSource2Rs.h"
 #include "SchemaSystem.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include "../deps/release/Detours/src/detours.h"
 
 #include <map>

--- a/AfxHookSource2/MirvCommands.cpp
+++ b/AfxHookSource2/MirvCommands.cpp
@@ -1,10 +1,11 @@
 #include "MirvCommands.h"
-#include "ClientEntitySystem.h"
 
 #include "../shared/StringTools.h"
 
+#include "ClientEntitySystem.h"
 #include "SceneSystem.h"
 #include "SchemaSystem.h"
+#include "VScript.h"
 
 bool g_bHookedMirvCommands = false;
 
@@ -532,3 +533,24 @@ void HookMirvCommands(HMODULE clientDll) {
 	g_bHookedMirvCommands = true;
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
+CON_COMMAND(mirv_vscript_client_exec, "Execute a vscript on the client VM.")
+{
+    int argC = args->ArgC();
+    const char * arg0 = args->ArgV(0);
+
+    if (2 <= argC) {
+        const char * arg1 = args->ArgV(1);
+		if(!ExecuteClientVScript(arg1)) {
+			advancedfx::Warning("Execution of cs_script failed.\n");
+		}
+		return;
+	}	
+
+
+	advancedfx::Message(
+        "%s <sValue> - Execute the given vscript on the client VM. Requires launch paramter \"-afxVScriptModeClient 1\", add \"-dev\" too to get cl_script_help command working.\n"
+        , arg0
+    );
+}

--- a/AfxHookSource2/VScript.cpp
+++ b/AfxHookSource2/VScript.cpp
@@ -1,0 +1,57 @@
+#include "stdafx.h"
+
+#include "VScript.h"
+
+#include "../shared/AfxCommandLine.h"
+
+#include "addresses.h"
+#include "Globals.h"
+
+#include <wchar.h>
+
+#include "../deps/release/Detours/src/detours.h"
+
+
+extern advancedfx::CCommandLine  * g_CommandLine;
+
+typedef int (__fastcall * cs2_client_CCSGOVScriptGameSystem_GetMode_t)(void * pThis);
+cs2_client_CCSGOVScriptGameSystem_GetMode_t g_Old_cs2_client_CCSGOVScriptGameSystem_GetMode = nullptr;
+int __fastcall New_cs2_client_CCSGOVScriptGameSystem_GetMode(void * pThis) {
+    static bool bFirsRun = true;
+    static int result = 2;
+    if(bFirsRun) {
+        bFirsRun = false;
+        result = g_Old_cs2_client_CCSGOVScriptGameSystem_GetMode(pThis);
+		if (int idx = g_CommandLine->FindParam(L"-afxVScriptModeClient")) {
+			if (idx + 1 < g_CommandLine->GetArgC()) {
+				result = (int)wcstol( g_CommandLine->GetArgV(idx + 1), nullptr, 10);
+			}
+		}        
+    }
+    return result;
+}
+
+void Hook_cs2_client_CCSGOVScriptGameSystem_GetMode() {
+    if (int idx = g_CommandLine->FindParam(L"-afxVScriptModeClient")) {
+        if(AFXADDR_GET(cs2_client_CCSGOVScriptGameSystem_GetMode)) {
+            g_Old_cs2_client_CCSGOVScriptGameSystem_GetMode = (cs2_client_CCSGOVScriptGameSystem_GetMode_t)AFXADDR_GET(cs2_client_CCSGOVScriptGameSystem_GetMode);
+            DetourTransactionBegin();
+            DetourUpdateThread(GetCurrentThread());
+            DetourAttach(&(PVOID&)g_Old_cs2_client_CCSGOVScriptGameSystem_GetMode,New_cs2_client_CCSGOVScriptGameSystem_GetMode);
+            if(NO_ERROR != DetourTransactionCommit()) ErrorBox(MkErrStr(__FILE__, __LINE__));        
+        }
+    }
+}
+
+bool ExecuteClientVScript(const char * pszScript) {
+    if(AFXADDR_GET(cs2_client_ClientScriptVM)) {
+        void *This = *(void**)AFXADDR_GET(cs2_client_ClientScriptVM);
+        void ** vtable = *(void***)This;        
+        void * pScript = ((void* (__fastcall *)(void *, const char *, void *)) (vtable[AFXADDR_GET(cs2_ScriptVM_CompileString_vtable_offset)])) (This,pszScript,nullptr);
+        if(nullptr == pScript) return false;
+        int result = ((int (__fastcall *)(void *, void *, unsigned char, unsigned char)) (vtable[AFXADDR_GET(cs2_ScriptVM_RunScript_vtable_offset)])) (This,pScript,0,1);
+        ((void (__fastcall *)(void *, void *)) (vtable[AFXADDR_GET(cs2_ScriptVM_FreeScript_vtable_offset)])) (This,pScript);
+        return -1 != result;
+    }
+    return false;
+}

--- a/AfxHookSource2/VScript.h
+++ b/AfxHookSource2/VScript.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void Hook_cs2_client_CCSGOVScriptGameSystem_GetMode();
+bool ExecuteClientVScript(const char * pszScript);

--- a/AfxHookSource2/addresses.cpp
+++ b/AfxHookSource2/addresses.cpp
@@ -16,6 +16,12 @@ AFXADDR_DEF(cs2_SceneSystem_FrameUpdate_vtable_idx);
 AFXADDR_DEF(cs2_deathmsg_lifetime_offset)
 AFXADDR_DEF(cs2_deathmsg_lifetimemod_offset)
 
+AFXADDR_DEF(cs2_client_CCSGOVScriptGameSystem_GetMode)
+AFXADDR_DEF(cs2_client_ClientScriptVM)
+AFXADDR_DEF(cs2_ScriptVM_CompileString_vtable_offset)
+AFXADDR_DEF(cs2_ScriptVM_RunScript_vtable_offset)
+AFXADDR_DEF(cs2_ScriptVM_FreeScript_vtable_offset)
+
 void Addresses_InitEngine2Dll(AfxAddr engine2Dll)
 {
 	MemRange textRange = MemRange(0, 0);
@@ -142,11 +148,17 @@ void Addresses_InitSceneSystemDll(AfxAddr sceneSystemDll) {
 
 void Addresses_InitClientDll(AfxAddr clientDll) {
 	MemRange textRange = MemRange(0, 0);
+      MemRange dataRange = MemRange(0, 0);
 	{
 		ImageSectionsReader imageSectionsReader((HMODULE)clientDll);
 		if (!imageSectionsReader.Eof())
 		{
 			textRange = imageSectionsReader.GetMemRange();
+                  imageSectionsReader.Next();
+                  if (!imageSectionsReader.Eof()) {
+                        dataRange = imageSectionsReader.GetMemRange();
+                  }
+      		else ErrorBox(MkErrStr(__FILE__, __LINE__));
 		}
 		else ErrorBox(MkErrStr(__FILE__, __LINE__));
 	}
@@ -168,4 +180,46 @@ void Addresses_InitClientDll(AfxAddr clientDll) {
 		else
 			ErrorBox(MkErrStr(__FILE__, __LINE__));
 	}
+
+      // cs2_client_CCSGOVScriptGameSystem_GetMode
+      //
+      // For more info see DevWarning("VM Did not start!\n");
+      {
+            if(size_t * vtable = (size_t*)Afx::BinUtils::FindClassVtable((HMODULE)clientDll,".?AVCCSGOVScriptGameSystem@@", 0, 0x0)) {
+                  AFXADDR_SET(cs2_client_CCSGOVScriptGameSystem_GetMode, vtable[63]);
+            }
+            else ErrorBox(MkErrStr(__FILE__, __LINE__));
+      }
+
+      // cs2_client_ClientScriptVM
+      // cs2_ScriptVM_CompileString_vtable_offset
+      // see LoggingSystem_Log(DAT_18251b6dc,3,"Error running script named %s\n",param_2);
+      {
+            MemRange result = FindCString(dataRange, "VM Did not start!\n");
+            if (!result.IsEmpty())
+            {
+                  size_t strAddr = result.Start;
+                  MemRange result2 = FindAddrInt32OffsetRefInContext(textRange, strAddr, (int32_t)sizeof(int32_t), "48 8d 0d", nullptr);
+                  if(!result2.IsEmpty()) {
+                        size_t addr = result2.Start - 0xF;
+                        unsigned char pattern[3] = { 0x48, 0x89, 0x05 };
+                        size_t patternSize = sizeof(pattern) / sizeof(pattern[0]);
+                        MemRange patternRange(addr, addr + patternSize);
+                        MemRange result3 = FindBytes(textRange.And(patternRange), (char *)pattern, patternSize);
+                        if (result3.Start != patternRange.Start || result3.End != patternRange.End)
+                        {
+                              addr = 0;
+                              ErrorBox(MkErrStr(__FILE__, __LINE__));
+                        } else {
+                              addr = addr+7+*(int32_t*)(addr+3);
+                              AFXADDR_SET(cs2_client_ClientScriptVM, addr);
+                              AFXADDR_SET(cs2_ScriptVM_CompileString_vtable_offset, 15);
+                              AFXADDR_SET(cs2_ScriptVM_RunScript_vtable_offset, 13);
+                              AFXADDR_SET(cs2_ScriptVM_FreeScript_vtable_offset, 16);
+                        }                 
+                  }
+                  else ErrorBox(MkErrStr(__FILE__, __LINE__));
+            }
+            else ErrorBox(MkErrStr(__FILE__, __LINE__));
+      }
 }

--- a/AfxHookSource2/addresses.h
+++ b/AfxHookSource2/addresses.h
@@ -11,6 +11,12 @@ AFXADDR_DECL(cs2_SceneSystem_FrameUpdate_vtable_idx)
 AFXADDR_DECL(cs2_deathmsg_lifetime_offset)
 AFXADDR_DECL(cs2_deathmsg_lifetimemod_offset)
 
+AFXADDR_DECL(cs2_client_CCSGOVScriptGameSystem_GetMode)
+AFXADDR_DECL(cs2_client_ClientScriptVM)
+AFXADDR_DECL(cs2_ScriptVM_CompileString_vtable_offset)
+AFXADDR_DECL(cs2_ScriptVM_RunScript_vtable_offset)
+AFXADDR_DECL(cs2_ScriptVM_FreeScript_vtable_offset)
+
 void Addresses_InitEngine2Dll(AfxAddr engine2Dll);
 
 void Addresses_InitSceneSystemDll(AfxAddr sceneSystemDll);

--- a/AfxHookSource2/main.cpp
+++ b/AfxHookSource2/main.cpp
@@ -21,6 +21,7 @@
 #include "MirvColors.h"
 #include "MirvFix.h"
 #include "MirvTime.h"
+#include "VScript.h"
 
 #include "../deps/release/prop/AfxHookSource/SourceSdkShared.h"
 #include "../deps/release/prop/AfxHookSource/SourceInterfaces.h"
@@ -2157,6 +2158,8 @@ void LibraryHooksW(HMODULE hModule, LPCWSTR lpLibFileName)
 		HookClientDll(hModule);
 
 		Hook_ClientEntitySystem3(hModule);
+
+		Hook_cs2_client_CCSGOVScriptGameSystem_GetMode();
 	} 
 	else if(bFirstPanorama && StringEndsWithW(lpLibFileName, L"panorama.dll"))
 	{

--- a/AfxHookSource2Rs/src/lib.rs
+++ b/AfxHookSource2Rs/src/lib.rs
@@ -85,6 +85,7 @@ unsafe extern "C" {
     fn afx_hook_source2_message(s: *const c_char);
     fn afx_hook_source2_warning(s: *const c_char);
     fn afx_hook_source2_exec(s: *const c_char);
+    fn afx_hook_source2_vscript_exec_client(s: *const c_char) -> bool;
 
     fn afx_hook_source2_enable_on_record_start(value: bool);
     fn afx_hook_source2_enable_on_record_end(value: bool);
@@ -778,6 +779,14 @@ fn afx_exec(s: String) {
     }
 }
 
+fn afx_vscript_exec_client(s: String) -> bool{
+    let c_string = std::ffi::CString::new(s).unwrap();
+    unsafe {
+        afx_hook_source2_vscript_exec_client(c_string.as_ptr())
+    }
+}
+
+
 fn afx_enable_on_record_start(value: bool) {
     unsafe {
         afx_hook_source2_enable_on_record_start(value);        
@@ -1209,6 +1218,21 @@ fn mirv_exec(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
         match x.to_string(context) {
             Ok(s) => {
                 afx_exec(s.to_std_string_escaped());
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        }
+    }
+    return Ok(JsValue::undefined())
+}
+
+fn mirv_vscript_exec_client(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    if 1 == args.len() {
+        match args[0].to_string(context) {
+            Ok(s) => {
+                let result: bool = afx_vscript_exec_client(s.to_std_string_escaped());
+                return Ok(js_value!(result));
             }
             Err(e) => {
                 return Err(e);
@@ -2640,6 +2664,11 @@ impl<'a> AfxHookSource2Rs<'a> {
         .function(
             NativeFunction::from_fn_ptr(mirv_exec),
             js_string!("exec"),
+            0,
+        )
+        .function(
+            NativeFunction::from_fn_ptr(mirv_vscript_exec_client),
+            js_string!("vScriptExecClient"),
             0,
         )
         .function(

--- a/misc/mirv-script/src/types/mirv.d.ts
+++ b/misc/mirv-script/src/types/mirv.d.ts
@@ -88,6 +88,16 @@ declare namespace mirv {
 	function exec(command: string): void;
 
 	/**
+	 * Execute a client.dll VScript.
+	 * @param script The script to execute.
+	 * @remarks Currently will only work if the game was launched with the option "-afxVScriptModeClient 1", add "-dev" to make cl_script_help command work.
+	 * @returns true upon success, otherwise false
+	 *
+	 * Since HLAE 2.162.0
+	 */
+	function vScriptExecClient(script: string): boolean;
+
+	/**
 	 * Load a JavaScript module (.mjs) or execute script (.js).
 	 * @param filePath - Full path to file to load.
 	 *


### PR DESCRIPTION
Adds console command and mirv-script function (mirv.vScriptExecClient) to execute VScripts on the client.dll VM.

For this to work the command line option -afxVScriptModeClient 1 needs to be added currently. Addtionally you might want to add -dev for making cl_script_help command work.

For more info see https://developer.valvesoftware.com/wiki/VScript (Lua), but please take into account that you should not confuse server.dll scripts (most there are for server I think) with client.dll scripts.

## Notes

Not sure if it makes sense to merge this:
- For server.dll Valve is pursuing cs_script (v8 JavaScript), but there's no such thing for client.dll.
- While there's many functions that can be called, it's still sort of limited.
- Valve might remove client-side VScript support (normally it's a stub, just tricked it into filling in the non-stubbed version)

## Examples

```js
mirv.vScriptExecClient(`
	local function list_globals()
		print("=== Global Variables ===")
		for key, value in pairs(_G) do
			-- Skip the _G reference to avoid recursion
			if key ~= "_G" then
				print(string.format("%-20s  (%s)", tostring(key), type(value)))
			end
		end
	end	
	
	list_globals()

	Msg( "Hello World!\\n" )
	Warning( "A warning.\\n" )
	Msg( "Map: " )
	Msg( GetMapName() )
	Msg( "\\n" )
	StartSoundEvent("UI.PlayerPingUrgent", Entities:GetLocalPlayerPawn())
	
	DebugDrawScreenTextLine(0,0,1,"Hello World!",255,255,0,255,10)

	print(_VERSION)
`)
```

## Related

- https://typescripttolua.github.io/docs/api/overview