### PR TITLE
fix: correct mirv_script campath JS setAngles binding typo

### DIFF
--- a/AfxHookSource2Rs/src/advancedfx/js/campath/mod.rs
+++ b/AfxHookSource2Rs/src/advancedfx/js/campath/mod.rs
@@ -1159,7 +1159,7 @@ impl Class for Campath {
                 NativeFunction::from_fn_ptr(Campath::set_position)
             ) 
             .method(
-                js_string!("setAngels"),
+                js_string!("setAngles"),
                 3,
                 NativeFunction::from_fn_ptr(Campath::set_angles)
             )


### PR DESCRIPTION
export `setAngles` instead of `setAngels`, which align the runtime binding with the existing TypeScript declaration