### PR TITLE
Add CS2 demo voice HUD fix

### DIFF
--- a/AfxHookSource2/CMakeLists.txt
+++ b/AfxHookSource2/CMakeLists.txt
@@ -244,6 +244,9 @@ target_sources(${PROJECT_NAME} PRIVATE
 	MirvFix.cpp
 	MirvFix.h
 
+	MirvVoiceHudFix.cpp
+	MirvVoiceHudFix.h
+
 	MirvTime.cpp
 	MirvTime.h
 

--- a/AfxHookSource2/MirvVoiceHudFix.cpp
+++ b/AfxHookSource2/MirvVoiceHudFix.cpp
@@ -1,0 +1,185 @@
+#include "stdafx.h"
+
+#include "MirvVoiceHudFix.h"
+
+#include "WrpConsole.h"
+#include "Globals.h"
+#include "addresses.h"
+#include "MirvTime.h"
+
+#include "../shared/AfxDetours.h"
+#include "../deps/release/prop/AfxHookSource/SourceSdkShared.h"
+#include "../deps/release/prop/cs2/sdk_src/public/cdll_int.h"
+
+#include <intrin.h>
+#include <limits.h>
+
+#pragma intrinsic(_ReturnAddress)
+
+extern SOURCESDK::CS2::ISource2EngineToClient * g_pEngineToClient;
+
+namespace {
+
+bool g_Enabled = false;
+
+// ISource2EngineToClient::IsPlayingDemo. Confirmed from the client.dll speaker-icon
+// call site (call qword [rax+0x150] => 0x150/8) and matches MulNX_CS2.
+const int kIsPlayingDemoVtableIndex = 42;
+
+// A backward jump, or a forward jump larger than this between render frames, is a seek.
+const int kSeekThresholdTicks = 16;
+const float kSyntheticSpeakingSeconds = 0.65f;
+
+int g_LastDemoTick = INT_MIN;
+float g_SyntheticSpeakingUntil[64] = {};
+
+typedef bool (*IsPlayingDemo_t)(void* This);
+IsPlayingDemo_t g_OldIsPlayingDemo = nullptr;
+bool g_IsPlayingDemoHookInstalled = false;
+
+typedef __int64 (__fastcall *ServerVoiceData_t)(__int64 This, __int64 msg);
+ServerVoiceData_t g_OldServerVoiceData = nullptr;
+bool g_ServerVoiceDataHookInstalled = false;
+
+typedef __int64 (__fastcall *VoiceStatus_Get_t)();
+typedef __int64 (__fastcall *VoiceStatus_UpdateSpeakerStatus_t)(__int64 voiceStatus, unsigned int playerSlot, int localSlot, unsigned __int8 talking);
+
+bool IsVoiceStatusReady() {
+    return AFXADDR_GET(cs2_client_VoiceStatus_Get) && AFXADDR_GET(cs2_client_VoiceStatus_UpdateSpeakerStatus);
+}
+
+void SetSyntheticSpeaking(unsigned int playerSlot, bool speaking) {
+    if (64 <= playerSlot || !IsVoiceStatusReady()) return;
+
+    __int64 voiceStatus = ((VoiceStatus_Get_t)AFXADDR_GET(cs2_client_VoiceStatus_Get))();
+    if (!voiceStatus) return;
+
+    ((VoiceStatus_UpdateSpeakerStatus_t)AFXADDR_GET(cs2_client_VoiceStatus_UpdateSpeakerStatus))(voiceStatus, playerSlot, -1, speaking ? 1 : 0);
+    g_SyntheticSpeakingUntil[playerSlot] = speaking ? g_MirvTime.curtime_get() + kSyntheticSpeakingSeconds : 0.0f;
+}
+
+void ClearSyntheticSpeaking() {
+    for (int i = 0; i < 64; ++i) {
+        if (0.0f < g_SyntheticSpeakingUntil[i])
+            SetSyntheticSpeaking(i, false);
+        g_SyntheticSpeakingUntil[i] = 0.0f;
+    }
+}
+
+void UpdateSyntheticSpeakingExpiry() {
+    float curTime = g_MirvTime.curtime_get();
+    for (int i = 0; i < 64; ++i) {
+        if (0.0f < g_SyntheticSpeakingUntil[i] && g_SyntheticSpeakingUntil[i] <= curTime)
+            SetSyntheticSpeaking(i, false);
+    }
+}
+
+// The game gates the speaker icon behind this IsPlayingDemo() call. Forcing it to false
+// *only at that call site* makes the non-demo (icon-drawing) path run during demos, while
+// every other IsPlayingDemo caller still sees the real value.
+bool new_IsPlayingDemo(void* This) {
+    void* ret = _ReturnAddress();
+    bool result = g_OldIsPlayingDemo(This);
+    if (g_Enabled) {
+        AfxAddr retAddr = AFXADDR_GET(cs2_client_ShowSpeaker_IsPlayingDemo_RetAddr);
+        if (retAddr && (AfxAddr)ret == retAddr)
+            return false;
+    }
+    return result;
+}
+
+__int64 __fastcall new_ServerVoiceData(__int64 This, __int64 msg) {
+    unsigned int playerSlot = msg ? *(unsigned int *)(msg + 104) : 0xFFFFFFFF;
+    __int64 result = g_OldServerVoiceData(This, msg);
+    if (g_Enabled && playerSlot < 64)
+        SetSyntheticSpeaking(playerSlot, true);
+    return result;
+}
+
+bool EnsureHookInstalled() {
+    if (!g_IsPlayingDemoHookInstalled) {
+        if (!g_pEngineToClient) return false;
+        void** vtable = *(void***)g_pEngineToClient;
+        if (!vtable) return false;
+        if (!AfxDetourPtr((PVOID*)&(vtable[kIsPlayingDemoVtableIndex]), new_IsPlayingDemo, (PVOID*)&g_OldIsPlayingDemo))
+            return false;
+        g_IsPlayingDemoHookInstalled = true;
+    }
+
+    if (!g_ServerVoiceDataHookInstalled) {
+        if (!AFXADDR_GET(cs2_client_ServerVoiceData)) return false;
+        g_OldServerVoiceData = (ServerVoiceData_t)AFXADDR_GET(cs2_client_ServerVoiceData);
+        DetourTransactionBegin();
+        DetourUpdateThread(GetCurrentThread());
+        DetourAttach(&(PVOID&)g_OldServerVoiceData, new_ServerVoiceData);
+        if (NO_ERROR != DetourTransactionCommit())
+            return false;
+        g_ServerVoiceDataHookInstalled = true;
+    }
+
+    return true;
+}
+
+} // namespace
+
+void MirvVoiceHudFix_OnRenderPass() {
+    if (!g_Enabled || !g_pEngineToClient) return;
+
+    auto pDemoFile = g_pEngineToClient->GetDemoFile();
+    if (!pDemoFile) { g_LastDemoTick = INT_MIN; ClearSyntheticSpeaking(); return; }
+
+    int curTick = pDemoFile->GetDemoTick();
+    if (g_LastDemoTick != INT_MIN) {
+        int delta = curTick - g_LastDemoTick;
+        if (delta < 0 || delta > kSeekThresholdTicks) {
+            g_pEngineToClient->ExecuteClientCmd(0, "servervoice_clear", true);
+            ClearSyntheticSpeaking();
+        }
+    }
+    g_LastDemoTick = curTick;
+    UpdateSyntheticSpeakingExpiry();
+}
+
+CON_COMMAND(mirv_voiceHudFix, "Show speaker (voice) icons in demo HUD; resets them on demo seek.") {
+    int argc = args->ArgC();
+    auto arg0 = args->ArgV(0);
+
+    if (2 <= argc) {
+        bool enable = 0 != atoi(args->ArgV(1));
+        if (enable) {
+            if (0 == AFXADDR_GET(cs2_client_ShowSpeaker_IsPlayingDemo_RetAddr)) {
+                advancedfx::Warning("%s: speaker code site not found in this client.dll build; cannot enable.\n", arg0);
+                return;
+            }
+            if (0 == AFXADDR_GET(cs2_client_ServerVoiceData)
+                || 0 == AFXADDR_GET(cs2_client_VoiceStatus_Get)
+                || 0 == AFXADDR_GET(cs2_client_VoiceStatus_UpdateSpeakerStatus)) {
+                advancedfx::Warning("%s: voice HUD helper code not found in this client.dll build; cannot enable.\n", arg0);
+                return;
+            }
+            if (!EnsureHookInstalled()) {
+                advancedfx::Warning("%s: failed to install hook (engine interface not ready yet?).\n", arg0);
+                return;
+            }
+        }
+        else {
+            ClearSyntheticSpeaking();
+        }
+        g_Enabled = enable;
+        g_LastDemoTick = INT_MIN;
+        advancedfx::Message("%s: %s\n", arg0, g_Enabled ? "enabled" : "disabled");
+        return;
+    }
+
+    advancedfx::Message(
+        "%s <0|1> - Show speaker (voice) icons in demo playback (default: 0).\n"
+        "Current value: %d\n"
+        "Speaker code site %s.\n"
+        "Server voice hook site %s.\n"
+        "VoiceStatus helpers %s.\n"
+        , arg0, g_Enabled ? 1 : 0
+        , AFXADDR_GET(cs2_client_ShowSpeaker_IsPlayingDemo_RetAddr) ? "resolved" : "NOT FOUND"
+        , AFXADDR_GET(cs2_client_ServerVoiceData) ? "resolved" : "NOT FOUND"
+        , IsVoiceStatusReady() ? "resolved" : "NOT FOUND"
+    );
+}

--- a/AfxHookSource2/MirvVoiceHudFix.h
+++ b/AfxHookSource2/MirvVoiceHudFix.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void MirvVoiceHudFix_OnRenderPass();

--- a/AfxHookSource2/addresses.cpp
+++ b/AfxHookSource2/addresses.cpp
@@ -16,6 +16,11 @@ AFXADDR_DEF(cs2_SceneSystem_FrameUpdate_vtable_idx);
 AFXADDR_DEF(cs2_deathmsg_lifetime_offset)
 AFXADDR_DEF(cs2_deathmsg_lifetimemod_offset)
 
+AFXADDR_DEF(cs2_client_ShowSpeaker_IsPlayingDemo_RetAddr)
+AFXADDR_DEF(cs2_client_ServerVoiceData)
+AFXADDR_DEF(cs2_client_VoiceStatus_Get)
+AFXADDR_DEF(cs2_client_VoiceStatus_UpdateSpeakerStatus)
+
 void Addresses_InitEngine2Dll(AfxAddr engine2Dll)
 {
 	MemRange textRange = MemRange(0, 0);
@@ -167,5 +172,31 @@ void Addresses_InitClientDll(AfxAddr clientDll) {
 		}
 		else
 			ErrorBox(MkErrStr(__FILE__, __LINE__));
+	}
+
+	{
+		MemRange result = FindPatternString(textRange, "48 63 C3 48 8D 0D ?? ?? ?? ?? C6 84 08 ?? ?? ?? ?? 01 48 8B 0D ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ?? 84 C0 0F 85");
+		if (!result.IsEmpty()) {
+			AFXADDR_SET(cs2_client_ShowSpeaker_IsPlayingDemo_RetAddr, result.Start + 0x22);
+		}
+	}
+
+	{
+		MemRange result = FindPatternString(textRange, "48 89 4C 24 ?? 53 55 56 57 41 54 41 55 41 57 48 81 EC");
+		if (!result.IsEmpty()) {
+			AFXADDR_SET(cs2_client_ServerVoiceData, result.Start);
+		}
+	}
+	{
+		MemRange result = FindPatternString(textRange, "48 8B 05 ?? ?? ?? ?? C3 CC CC CC CC CC CC CC CC 48 8D 05");
+		if (!result.IsEmpty()) {
+			AFXADDR_SET(cs2_client_VoiceStatus_Get, result.Start);
+		}
+	}
+	{
+		MemRange result = FindPatternString(textRange, "44 88 4C 24 ?? 44 89 44 24 ?? 89 54 24");
+		if (!result.IsEmpty()) {
+			AFXADDR_SET(cs2_client_VoiceStatus_UpdateSpeakerStatus, result.Start);
+		}
 	}
 }

--- a/AfxHookSource2/addresses.h
+++ b/AfxHookSource2/addresses.h
@@ -11,6 +11,11 @@ AFXADDR_DECL(cs2_SceneSystem_FrameUpdate_vtable_idx)
 AFXADDR_DECL(cs2_deathmsg_lifetime_offset)
 AFXADDR_DECL(cs2_deathmsg_lifetimemod_offset)
 
+AFXADDR_DECL(cs2_client_ShowSpeaker_IsPlayingDemo_RetAddr)
+AFXADDR_DECL(cs2_client_ServerVoiceData)
+AFXADDR_DECL(cs2_client_VoiceStatus_Get)
+AFXADDR_DECL(cs2_client_VoiceStatus_UpdateSpeakerStatus)
+
 void Addresses_InitEngine2Dll(AfxAddr engine2Dll);
 
 void Addresses_InitSceneSystemDll(AfxAddr sceneSystemDll);

--- a/AfxHookSource2/main.cpp
+++ b/AfxHookSource2/main.cpp
@@ -21,6 +21,7 @@
 #include "MirvColors.h"
 #include "MirvFix.h"
 #include "MirvTime.h"
+#include "MirvVoiceHudFix.h"
 
 #include "../deps/release/prop/AfxHookSource/SourceSdkShared.h"
 #include "../deps/release/prop/AfxHookSource/SourceInterfaces.h"
@@ -1503,6 +1504,7 @@ void  new_CS2_Client_FrameStageNotify(void* This, SOURCESDK::CS2::ClientFrameSta
 	switch(curStage) {
 	case SOURCESDK::CS2::FRAME_RENDER_PASS:
 		g_CommandSystem.OnExecuteCommands();
+		MirvVoiceHudFix_OnRenderPass();
 		break;
 	}
 


### PR DESCRIPTION
## Summary
- Add `mirv_voiceHudFix 0|1` for CS2 demo playback speaker icons.
- Scope the `IsPlayingDemo()` override to the speaker HUD call site only, so normal demo checks keep their original behavior.
- Hook server voice chunks and update `CVoiceStatus` speaker state with short synthetic expiry, allowing HUD recovery after seeking into the middle of voice playback.
- Clear synthetic speaking state on demo tick jumps or disable to avoid stale speaker icons.

## Implementation notes
- Resolves the speaker HUD call-site return address, server voice handler, and `VoiceStatus` helper functions from `client.dll` patterns.
- Installs hooks lazily when `mirv_voiceHudFix 1` is enabled.
- Runs per `FRAME_RENDER_PASS` to detect demo seeks and expire synthetic speaker states.

## Test plan
- Built `AfxHookSource2` x64 from an isolated worktree build directory.
- Installed the resulting DLL into the local HLAE x64 target and verified matching MD5 hashes.
- Smoke-tested in CS2 demo playback: `mirv_voiceHudFix 1` appears to enable speaker HUD icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)