### PR TITLE
Improve Source 2 hook resilience across CS2 updates

### DIFF
--- a/AfxHookSource2/DeathMsg.cpp
+++ b/AfxHookSource2/DeathMsg.cpp
@@ -1423,6 +1423,8 @@ bool getPanoramaAddrs(HMODULE panoramaDll) {
 		// Resolve style properties through Panorama's own lookup function. This
 		// avoids depending on the private map layout for normal operation while
 		// retaining the map below for diagnostics and as a fallback.
+		//
+		// fn refernces string "panorama::CStyleSymbol::CStyleSymbol" 4 times
 		auto addr = getAddress(panoramaDll, "40 55 56 57 41 54 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 44 8B 05 ?? ?? ?? ?? 48 8B F9 65 48 8B 04 25 58 00 00 00 45 33 E4 C6 01 FF 48 8B F2");
 		if (addr) {
 			g_PanoramaStylePropertySymbols.resolve = (StylePropertySymbolMap::Resolve_t)addr;
@@ -1430,6 +1432,7 @@ bool getPanoramaAddrs(HMODULE panoramaDll) {
 	}
 
 	{
+		// (in function of g_PanoramaStylePropertySymbols.resolve)
 		// before it jumps to error branch for "Need to increase size of static g_StylePropertyRegistrations (MAX_PANORAMA_STYLE_SYMBOLS) before registering more styles, failed on %s"
 		/*
       		lVar9 = DAT_180510350;
@@ -1444,7 +1447,7 @@ bool getPanoramaAddrs(HMODULE panoramaDll) {
 			local_70 = local_80;
 			FUN_180099640(&DAT_180510348,iVar5,local_78); <-- DAT_180510348 is what we are after, since might sometimes be the result of a function called before this one, but right now it's inlined.
 			_DAT_18051035c = _DAT_18051035c + 1;
-	  */
+	  	*/
 		auto addr = getAddress(panoramaDll, "0f 10 45 f7 48 8d 0d ?? ?? ?? ?? 41 f7 c0 ff ff ff 7f");
 		if (0 == addr) {
 			if (!g_PanoramaStylePropertySymbols.resolve) {

--- a/AfxHookSource2/DeathMsg.cpp
+++ b/AfxHookSource2/DeathMsg.cpp
@@ -51,7 +51,15 @@ struct CPanel2D {
 };
 
 struct StylePropertySymbolMap {
+    typedef uint8_t* (__fastcall *Resolve_t)(uint8_t* out, const char* stylePropertyName);
+
     uint8_t findSymbol(const char* stylePropertyName) {
+        if (resolve) {
+            uint8_t result = 0xFF;
+            resolve(&result, stylePropertyName);
+            return result;
+        }
+
         if (!symbols) return 0xFF;
 
 		for (int i = 0; i < symbols->numElements; ++i) {
@@ -62,11 +70,16 @@ struct StylePropertySymbolMap {
         return 0xFF;
     }
 
-    SOURCESDK::CS2::CUtlMap<SOURCESDK::CS2::CUtlString, uint8_t>* symbols;
+    Resolve_t resolve = nullptr;
+    SOURCESDK::CS2::CUtlMap<SOURCESDK::CS2::CUtlString, uint8_t>* symbols = nullptr;
 } g_PanoramaStylePropertySymbols;
 
 CON_COMMAND(__mirv_panorama_dump_style_symbols, "") {
 	auto symbols = g_PanoramaStylePropertySymbols.symbols;
+	if (!symbols) {
+		advancedfx::Warning("AFXWARNING: Panorama style-symbol dumping is unavailable for this CS2 build.\n");
+		return;
+	}
 
 	for (int i = 0; i < symbols->numElements; ++i) {
 		auto node = symbols->memory[i];
@@ -1407,6 +1420,16 @@ bool getPanoramaAddrs(HMODULE panoramaDll) {
 	}		
 
 	{
+		// Resolve style properties through Panorama's own lookup function. This
+		// avoids depending on the private map layout for normal operation while
+		// retaining the map below for diagnostics and as a fallback.
+		auto addr = getAddress(panoramaDll, "40 55 56 57 41 54 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 44 8B 05 ?? ?? ?? ?? 48 8B F9 65 48 8B 04 25 58 00 00 00 45 33 E4 C6 01 FF 48 8B F2");
+		if (addr) {
+			g_PanoramaStylePropertySymbols.resolve = (StylePropertySymbolMap::Resolve_t)addr;
+		}
+	}
+
+	{
 		// before it jumps to error branch for "Need to increase size of static g_StylePropertyRegistrations (MAX_PANORAMA_STYLE_SYMBOLS) before registering more styles, failed on %s"
 		/*
       		lVar9 = DAT_180510350;
@@ -1423,8 +1446,13 @@ bool getPanoramaAddrs(HMODULE panoramaDll) {
 			_DAT_18051035c = _DAT_18051035c + 1;
 	  */
 		auto addr = getAddress(panoramaDll, "0f 10 45 f7 48 8d 0d ?? ?? ?? ?? 41 f7 c0 ff ff ff 7f");
-		if (0 == addr)
-			ErrorBox(MkErrStr(__FILE__, __LINE__));	
+		if (0 == addr) {
+			if (!g_PanoramaStylePropertySymbols.resolve) {
+				ErrorBox(MkErrStr(__FILE__, __LINE__));
+				return false;
+			}
+			advancedfx::Warning("AFXWARNING: Panorama style-symbol map is unavailable; style lookup will use the resolver.\n");
+		}
 		else {
 			auto out = addr + 11 + *(int32_t*)(addr + 7);
 			g_PanoramaStylePropertySymbols.symbols = (SOURCESDK::CS2::CUtlMap<SOURCESDK::CS2::CUtlString, uint8_t>*)(out);

--- a/AfxHookSource2/MirvCommands.cpp
+++ b/AfxHookSource2/MirvCommands.cpp
@@ -467,8 +467,7 @@ bool getAddressesFromClient(HMODULE clientDll) {
 	// in func itself it starts with 'if (*(char *)(param_1 + 0x38) != '\0')'
 	size_t g_Original_EOM_addr = getAddress(clientDll, "40 56 48 83 ec 40 80 79 38 00 48 8b f1 0f 84 ?? ?? ?? ?? 48 89 5c 24 58 48 89 6c 24 60 4c 89 64 24 30 45 33 e4");
 	if(g_Original_EOM_addr == 0) {
-		ErrorBox(MkErrStr(__FILE__, __LINE__));
-		res = false;
+		advancedfx::Warning("AFXWARNING: mirv_endofmatch is unavailable for this CS2 build.\n");
 	}
 
 	// See where spec_show_xray is checked, has offsets to glowProperty
@@ -529,7 +528,7 @@ void HookMirvCommands(HMODULE clientDll) {
     DetourUpdateThread(GetCurrentThread());
 
 	DetourAttach(&(PVOID&)g_Original_OnFlashMaxAlphaChanged, new_OnFlashMaxAlphaChanged);
-	DetourAttach(&(PVOID&)g_Original_EOM, new_EOM);
+	if (g_Original_EOM) DetourAttach(&(PVOID&)g_Original_EOM, new_EOM);
 	DetourAttach(&(PVOID&)g_Original_setGlowProps, new_setGlowProps);
 	DetourAttach(&(PVOID&)org_shouldGlow, new_shouldGlow);
 	DetourAttach(&(PVOID&)org_ForceUpdateSkybox, new_ForceUpdateSkybox);

--- a/AfxHookSource2/ReplaceName.cpp
+++ b/AfxHookSource2/ReplaceName.cpp
@@ -115,8 +115,8 @@ void HookReplaceName(HMODULE clientDll)
 			DetourUpdateThread(GetCurrentThread());
 			DetourAttach(&(PVOID&)g_Org_GetDecoratedPlayerName, New_GetDecoratedPlayerName);
 			if(NO_ERROR != DetourTransactionCommit()) ErrorBox(MkErrStr(__FILE__, __LINE__));
-		} 
-		else ErrorBox(MkErrStr(__FILE__, __LINE__));
+		}
+		else advancedfx::Warning("AFXWARNING: decorated player-name replacement is unavailable for this CS2 build.\n");
 
         // fn has 3rd reference to string "WWWWWWWWWWWWWWWW"
         if(void ** vtable = (void **)Afx::BinUtils::FindClassVtable(clientDll, ".?AVCCSPlayerController@@", 0, 0)) {


### PR DESCRIPTION
Supersedes #1192, which was automatically closed when its `cs2-update` base branch was deleted.
Related to #1186.

## Why this shape

CS2 updates can invalidate several independent reverse-engineered addresses in one release.
Treating every address as equally critical lets a break in a cosmetic or optional path prevent unrelated recording and camera hooks from loading.
That failure boundary is too broad: a partial compatibility regression becomes a total one even when the requested workflow never uses the affected capability.

This change keeps the failure boundary around the capability that owns the missing address.
Capture-critical hooks still fail fast.
Optional end-of-match suppression and decorated-name replacement instead leave the rest of AfxHookSource2 available and emit explicit warnings.
The warnings are intentional: continuing silently would make the next game update harder to diagnose, while a modal error makes automated capture impossible despite the core hook remaining usable.

Panorama style symbols have a different resilience problem.
Walking Panorama's private `CUtlMap` couples normal opacity operations to both an address signature and an internal container layout.
The July update demonstrated that the storage can move or be inlined even when Panorama's lookup behavior remains available.
Asking Panorama's own resolver to perform normal lookup keeps ownership of that private layout inside Panorama.
The map remains available for diagnostics and as a fallback, so `__mirv_panorama_dump_style_symbols` is preserved on builds where the container can still be located.
HLAE still stops Panorama hook installation when neither route is available, because proceeding in that state would make style operations incorrect rather than merely disable an optional feature.

The scope is deliberately limited to resilience behavior on top of the CS2 fixes now merged into `main`.
It does not duplicate or claim the signatures and offsets credited in #1186, and it does not include downstream packaging, binaries, or recorder behavior.

## Validation

- `cmake --preset x64-debug`
- `cmake --build --preset x64-debug --target AfxHookSource2`
- Produced `AfxHookSource2_d.dll` successfully after rebasing onto `main`, with no new compiler warnings from the modified files.
- `ctest --test-dir build/x64-debug -C Debug --output-on-failure` reports that this preset registers no tests.

The configure step needed a local, uncommitted `vswhere -products "*"` workaround because the test machine has Visual Studio Build Tools rather than a full Visual Studio product.
That build-system workaround is intentionally not part of this PR.

An earlier version of the Panorama resolver path was exercised against CS2 `1.41.6.8` in a real HLAE recording and produced 1920x1080 at 60 fps with the expected POV, HUD, radar, crosshair, killfeed, and audio.
This rebased commit has been compile-validated but has not been launched in CS2, so runtime confirmation remains outstanding.
